### PR TITLE
Use errors and fmt.Errorf instead of github.com/pkg/errors

### DIFF
--- a/editor.go
+++ b/editor.go
@@ -3,8 +3,6 @@ package manager
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/cilium/ebpf/asm"
 )
 
@@ -56,7 +54,7 @@ func (ed *Editor) RewriteConstant(symbol string, value uint64) error {
 	for _, index := range indices {
 		load := &(*ed.instructions)[index]
 		if load.OpCode != ldDWImm {
-			return errors.Errorf("symbol %v: load: found %v instead of %v", symbol, load.OpCode, ldDWImm)
+			return fmt.Errorf("symbol %v: load: found %v instead of %v", symbol, load.OpCode, ldDWImm)
 		}
 
 		load.Constant = int64(value)

--- a/err.go
+++ b/err.go
@@ -1,6 +1,6 @@
 package manager
 
-import "github.com/pkg/errors"
+import "errors"
 
 var (
 	ErrManagerNotInitialized    = errors.New("the manager must be initialized first")

--- a/examples/activated_probes/utils.go
+++ b/examples/activated_probes/utils.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +13,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/clone_vs_add_hook/utils.go
+++ b/examples/clone_vs_add_hook/utils.go
@@ -3,12 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"os"
 	"time"
 	"unsafe"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,7 +36,7 @@ func getHostByteOrder() binary.ByteOrder {
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/map_rewrite_vs_map_router/demo.go
+++ b/examples/map_rewrite_vs_map_router/demo.go
@@ -1,8 +1,9 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/cilium/ebpf"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -13,7 +14,7 @@ func demoMapEditor() error {
 	// Select the shared map to give it to m2
 	sharedCache1, found, err := m1.GetMap("shared_cache1")
 	if err != nil || !found {
-		return errors.Wrap(err, "couldn't find shared_cache1 in m1")
+		return fmt.Errorf("couldn't find shared_cache1 in m1: %w", err)
 	}
 	if err = dumpSharedMap(sharedCache1); err != nil {
 		return err
@@ -35,7 +36,7 @@ func demoMapEditor() error {
 	}
 	// Initialize m2, edit shared_cache1 and start it
 	if err = m2.InitWithOptions(recoverAsset("/prog2.o"), options); err != nil {
-		return errors.Wrap(err, "couldn't init m2")
+		return fmt.Errorf("couldn't init m2: %w", err)
 	}
 	if err = m2.Start(); err != nil {
 		return err
@@ -51,7 +52,7 @@ func demoMapRouter() error {
 	// Select the shared map to give it to m2
 	sharedCache2, found, err := m1.GetMap("shared_cache2")
 	if err != nil || !found {
-		return errors.Wrap(err, "couldn't find shared_cache2 in m1")
+		return fmt.Errorf("couldn't find shared_cache2 in m1: %w", err)
 	}
 	if err = dumpSharedMap(sharedCache2); err != nil {
 		return err

--- a/examples/map_rewrite_vs_map_router/utils.go
+++ b/examples/map_rewrite_vs_map_router/utils.go
@@ -3,12 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"os"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,7 +36,7 @@ func getHostByteOrder() binary.ByteOrder {
 func recoverAsset(asset string) io.ReaderAt {
 	buf, err := Asset(asset)
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/mapspec_editor/utils.go
+++ b/examples/mapspec_editor/utils.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -15,7 +14,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/object_pinning/utils.go
+++ b/examples/object_pinning/utils.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +13,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/program_router/utils.go
+++ b/examples/program_router/utils.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +13,7 @@ import (
 func recoverAssets(probe string) io.ReaderAt {
 	buf, err := Asset(probe)
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/programs/cgroup/utils.go
+++ b/examples/programs/cgroup/utils.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +13,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/programs/kprobe/utils.go
+++ b/examples/programs/kprobe/utils.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +13,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/programs/lsm/utils.go
+++ b/examples/programs/lsm/utils.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -12,7 +12,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/programs/socket/utils.go
+++ b/examples/programs/socket/utils.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +13,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/programs/tc/utils.go
+++ b/examples/programs/tc/utils.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +13,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/programs/tracepoint/utils.go
+++ b/examples/programs/tracepoint/utils.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +13,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/programs/uprobe/utils.go
+++ b/examples/programs/uprobe/utils.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os/exec"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -14,7 +14,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/programs/xdp/utils.go
+++ b/examples/programs/xdp/utils.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +13,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/examples/tests_and_benchmarks/utils.go
+++ b/examples/tests_and_benchmarks/utils.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -12,7 +12,7 @@ import (
 func recoverAssets() io.ReaderAt {
 	buf, err := Asset("/probe.o")
 	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "couldn't find asset"))
+		logrus.Fatal(fmt.Errorf("couldn't find asset: %w", err))
 	}
 	return bytes.NewReader(buf)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/ebpf-manager
 
-go 1.16
+go 1.15
 
 require (
 	github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321
@@ -8,8 +8,6 @@ require (
 	github.com/cilium/ebpf v0.6.2
 	github.com/florianl/go-tc v0.3.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/pkg/errors v0.9.1
-	github.com/shuLhan/go-bindata v4.0.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c

--- a/go.sum
+++ b/go.sum
@@ -56,14 +56,10 @@ github.com/mdlayher/netlink v1.2.2-0.20210123213345-5cc92139ae3e/go.mod h1:bacnN
 github.com/mdlayher/netlink v1.3.0/go.mod h1:xK/BssKuwcRXHrtN04UBkwQ6dY9VviGGuriDdoPSWys=
 github.com/mdlayher/netlink v1.4.0 h1:n3ARR+Fm0dDv37dj5wSWZXDKcy+U0zwcXS3zKMnSiT0=
 github.com/mdlayher/netlink v1.4.0/go.mod h1:dRJi5IABcZpBD2A3D0Mv/AiX8I9uDEu5oGkAVrekmf8=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
-github.com/shuLhan/go-bindata v4.0.0+incompatible h1:xD8LkuVZLV5OOn/IEuFdt6EEAW7deWiqgwaaSGhjAJc=
-github.com/shuLhan/go-bindata v4.0.0+incompatible/go.mod h1:pkcPAATLBDD2+SpAPnX5vEM90F7fcwHCvvLCMXcmw3g=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/map.go
+++ b/map.go
@@ -1,10 +1,9 @@
 package manager
 
 import (
+	"fmt"
 	"os"
 	"sync"
-
-	"github.com/pkg/errors"
 
 	"github.com/cilium/ebpf"
 )
@@ -93,7 +92,7 @@ func loadNewMap(spec ebpf.MapSpec, options MapOptions) (*Map, error) {
 	// Pin map if need be
 	if managerMap.PinPath != "" {
 		if err := managerMap.array.Pin(managerMap.PinPath); err != nil {
-			return nil, errors.Wrapf(err, "couldn't pin map %s at %s", managerMap.Name, managerMap.PinPath)
+			return nil, fmt.Errorf("couldn't pin map %s at %s: %w", managerMap.Name, managerMap.PinPath, err)
 		}
 	}
 	return &managerMap, nil
@@ -111,14 +110,14 @@ func (m *Map) Init(manager *Manager) error {
 	if m.array == nil {
 		array, ok := manager.collection.Maps[m.Name]
 		if !ok {
-			return errors.Wrapf(ErrUnknownSection, "couldn't find map at maps/%s", m.Name)
+			return fmt.Errorf("couldn't find map at maps/%s: %w", m.Name, ErrUnknownSection)
 		}
 		m.array = array
 
 		// Pin map if needed
 		if m.PinPath != "" {
 			if err := m.array.Pin(m.PinPath); err != nil {
-				return errors.Wrapf(err, "couldn't pin map %s at %s", m.Name, m.PinPath)
+				return fmt.Errorf("couldn't pin map %s at %s: %w", m.Name, m.PinPath, err)
 			}
 		}
 	}

--- a/perf.go
+++ b/perf.go
@@ -3,8 +3,6 @@ package manager
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/perf"
 )
@@ -145,7 +143,7 @@ func (m *PerfMap) Stop(cleanup MapCleanupType) error {
 		if err == nil {
 			err = errTmp
 		} else {
-			err = errors.Wrap(errTmp, err.Error())
+			err = fmt.Errorf("%s: %w", err.Error(), errTmp)
 		}
 	}
 	return err

--- a/selectors.go
+++ b/selectors.go
@@ -1,9 +1,8 @@
 package manager
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // OneOf - This selector is used to ensure that at least of a list of probe selectors is valid. In other words, this
@@ -31,7 +30,7 @@ func (oo *OneOf) RunValidator(manager *Manager) error {
 		}
 	}
 	if len(errs) == len(oo.Selectors) {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"OneOf requirement failed, none of the following probes are running [%s]",
 			strings.Join(errs, " | "))
 	}
@@ -80,7 +79,7 @@ func (ao *AllOf) RunValidator(manager *Manager) error {
 		}
 	}
 	if len(errMsg) > 0 {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"AllOf requirement failed, the following probes are not running [%s]",
 			strings.Join(errMsg, " | "))
 	}


### PR DESCRIPTION
### What does this PR do?

Use `errors` and `fmt.Errorf` instead of `github.com/pkg/errors`

### Motivation

Use stdlib where possible

### Additional Notes

based on branch for #2 