### PR TITLE
[kprobe/uprobe] Implement perf_event_open ABI to attach kprobes and uprobes

### DIFF
--- a/err.go
+++ b/err.go
@@ -21,4 +21,5 @@ var (
 	ErrMapInitialized           = errors.New("map already initialized")
 	ErrMapNotInitialized        = errors.New("the map must be initialized first")
 	ErrMapNotRunning            = errors.New("the map is not running")
+	ErrNotSupported             = errors.New("not supported")
 )

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/vishvananda/netlink v1.1.0
-	golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34
+	golang.org/x/sys v0.0.0-20210921065528-437939a70204
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1c8PVE1PubbNx3mjUr09OqWGCs=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
-github.com/cilium/ebpf v0.6.2 h1:iHsfF/t4aW4heW2YKfeHrVPGdtYTL4C4KocpM8KTSnI=
-github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.3-0.20210917122031-fc2955d2ecee h1:eg3Xm5uBYJLRDVq750EFFx9CHTOEFIH/MjLNNpyTS3Y=
 github.com/cilium/ebpf v0.6.3-0.20210917122031-fc2955d2ecee/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -103,10 +101,9 @@ golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210123111255-9b0068b26619/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210216163648-f7da38b97c65/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34 h1:GkvMjFtXUmahfDtashnc1mnrCtuBVcwse5QV2lUk/tI=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210921065528-437939a70204 h1:JJhkWtBuTQKyz2bd5WG9H8iUsJRU3En/KRfN8B2RnDs=
+golang.org/x/sys v0.0.0-20210921065528-437939a70204/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/manager.go
+++ b/manager.go
@@ -1562,7 +1562,7 @@ func cleanupKprobeEvents(pattern *regexp.Regexp, pidMask map[int]procMask) error
 		}
 
 		// remove the entry
-		cleanUpErrors = multierror.Append(cleanUpErrors, disableKprobeEvent(match[3]))
+		cleanUpErrors = multierror.Append(cleanUpErrors, unregisterKprobeEventWithEventName(match[3]))
 	}
 	return cleanUpErrors
 }
@@ -1603,7 +1603,7 @@ func cleanupUprobeEvents(pattern *regexp.Regexp, pidMask map[int]procMask) error
 		}
 
 		// remove the entry
-		cleanUpErrors = multierror.Append(cleanUpErrors, disableUprobeEvent(match[3]))
+		cleanUpErrors = multierror.Append(cleanUpErrors, unregisterUprobeEventWithEventName(match[3]))
 	}
 	return cleanUpErrors
 }

--- a/syscalls.go
+++ b/syscalls.go
@@ -1,7 +1,9 @@
 package manager
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"syscall"
 	"unsafe"
@@ -10,13 +12,83 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func perfEventOpenTracepoint(id int, progFd int) (*FD, error) {
+// perfEventOpenPMU - Kernel API with e12f03d ("perf/core: Implement the 'perf_kprobe' PMU") allows
+// creating [k,u]probe with perf_event_open, which makes it easier to clean up
+// the [k,u]probe. This function tries to create pfd with the perf_kprobe PMU.
+func perfEventOpenPMU(name string, offset, pid int, eventType string, retProbe bool, referenceCounterOffset uint64) (*FD, error) {
+	var err error
+	var attr unix.PerfEventAttr
+
+	// Getting the PMU type will fail if the kernel doesn't support
+	// the perf_[k,u]probe PMU.
+	attr.Type, err = getPMUEventType(eventType)
+	if err != nil {
+		return nil, err
+	}
+
+	if retProbe {
+		var retProbeBit uint64
+		retProbeBit, err = getRetProbeBit(eventType)
+		if err != nil {
+			return nil, err
+		}
+		attr.Config |= 1 << retProbeBit
+	}
+
+	if referenceCounterOffset > 0 {
+		attr.Config |= referenceCounterOffset << 32
+	}
+
+	// transform the symbol name or the uprobe path to a byte array
+	namePtr, err := syscall.BytePtrFromString(name)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create pointer to string %s: %w", name, err)
+	}
+
+	switch eventType {
+	case "kprobe":
+		attr.Ext1 = uint64(uintptr(unsafe.Pointer(namePtr))) // Kernel symbol to trace
+		pid = 0
+	case "uprobe":
+		// The minimum size required for PMU uprobes is PERF_ATTR_SIZE_VER1,
+		// since it added the config2 (Ext2) field. The Size field controls the
+		// size of the internal buffer the kernel allocates for reading the
+		// perf_event_attr argument from userspace.
+		attr.Size = unix.PERF_ATTR_SIZE_VER1
+		attr.Ext1 = uint64(uintptr(unsafe.Pointer(namePtr))) // Uprobe path
+		attr.Ext2 = uint64(offset)                           // Uprobe offset
+		// PID filter is only possible for uprobe events
+		if pid < 0 {
+			pid = -1
+		}
+	}
+
+	var efd int
+	efd, err = unix.PerfEventOpen(&attr, pid, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
+
+	// Since commit 97c753e62e6c, ENOENT is correctly returned instead of EINVAL
+	// when trying to create a kretprobe for a missing symbol. Make sure ENOENT
+	// is returned to the caller.
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL) {
+		return nil, fmt.Errorf("symbol '%s' not found: %w", name, os.ErrNotExist)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("opening perf event: %w", err)
+	}
+
+	// Ensure the string pointer is not collected before PerfEventOpen returns.
+	runtime.KeepAlive(unsafe.Pointer(namePtr))
+
+	return NewFD(uint32(efd)), nil
+}
+
+func perfEventOpenTracingEvent(probeID int) (*FD, error) {
 	attr := unix.PerfEventAttr{
 		Type:        unix.PERF_TYPE_TRACEPOINT,
 		Sample_type: unix.PERF_SAMPLE_RAW,
 		Sample:      1,
 		Wakeup:      1,
-		Config:      uint64(id),
+		Config:      uint64(probeID),
 	}
 	attr.Size = uint32(unsafe.Sizeof(attr))
 
@@ -24,15 +96,17 @@ func perfEventOpenTracepoint(id int, progFd int) (*FD, error) {
 	if efd < 0 {
 		return nil, fmt.Errorf("perf_event_open error: %w", err)
 	}
-
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(efd), unix.PERF_EVENT_IOC_ENABLE, 0); err != 0 {
-		return nil, fmt.Errorf("error enabling perf event: %w", err)
-	}
-
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(efd), unix.PERF_EVENT_IOC_SET_BPF, uintptr(progFd)); err != 0 {
-		return nil, fmt.Errorf("error attaching bpf program to perf event: %w", err)
-	}
 	return NewFD(uint32(efd)), nil
+}
+
+func ioctlPerfEventEnable(perfEventOpenFD *FD, progFD int) error {
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_SET_BPF, uintptr(progFD)); err != 0 {
+		return fmt.Errorf("error attaching bpf program to perf event: %w", err)
+	}
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_ENABLE, 0); err != 0 {
+		return fmt.Errorf("error enabling perf event: %w", err)
+	}
+	return nil
 }
 
 type bpfProgAttachAttr struct {


### PR DESCRIPTION
### What does this PR do?

This PR implements the new perf_event_open ABI to attach kprobes and uprobes (for 4.17+ kernels).

### Motivation

On some recent distributions (and container optimized OS like Bottlerocket), the debug filesystem isn't necessarily mounted and writable. With this PR, the manager will now use the new kernel ABI first, and fallback to the legacy "kprobe_events" method if the new ABI is not available.

### Describe how to test your changes

This change can be tested by making sure that the examples in this repository are running. We also ran the entire CI on system-probe in the Datadog agent repository.
