### PR TITLE
Dump eBPF maps info thanks to DumpHandler() callback

### DIFF
--- a/map.go
+++ b/map.go
@@ -44,6 +44,10 @@ type MapOptions struct {
 
 	// AlwaysCleanup - Overrides the clean up type given to the manager. See CleanupType for more.
 	AlwaysCleanup bool
+
+	// DumpHandler - Callback function called when manager.Dump() is called
+	// and dump the current state (human readable)
+	DumpHandler func(currentMap *Map, manager *Manager) string
 }
 
 type Map struct {


### PR DESCRIPTION
### What does this PR do?

DumpMaps(maps ...string) - Return a string containing human readable info about eBPF maps
Dumps the set of maps provided, otherwise dumping all maps with a DumpHandler callback.

### Motivation

Cherry pick and merge PR:
https://github.com/DataDog/ebpf/pull/52
https://github.com/DataDog/ebpf/pull/53
https://github.com/DataDog/ebpf/pull/55
