### PR TITLE
Return the last retry error when attaching/detaching probes

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -429,7 +429,7 @@ func (p *Probe) Attach() error {
 		}
 
 		return err
-	}, retry.Attempts(p.ProbeRetry), retry.Delay(p.ProbeRetryDelay))
+	}, retry.Attempts(p.ProbeRetry), retry.Delay(p.ProbeRetryDelay), retry.LastErrorOnly(true))
 }
 
 // attach - Thread unsafe version of attach
@@ -505,7 +505,7 @@ func (p *Probe) Detach() error {
 
 // detachRetry - Thread unsafe version of Detach with retry
 func (p *Probe) detachRetry() error {
-	return retry.Do(p.detach, retry.Attempts(p.ProbeRetry), retry.Delay(p.ProbeRetryDelay))
+	return retry.Do(p.detach, retry.Attempts(p.ProbeRetry), retry.Delay(p.ProbeRetryDelay), retry.LastErrorOnly(true))
 }
 
 // detach - Thread unsafe version of Detach.


### PR DESCRIPTION
### What does this PR do?

This PR configures the [retry-go](https://github.com/avast/retry-go) library to return the last error instead of an aggregate error when attaching and detaching probes.

### Motivation

While returning an aggregate error ultimately gives more information about the operation, it ends up hiding the root cause of the returned error when it is printed using the `%s` format verb. For example, in the datadog-agent repo, when attaching a probe, any error that occurs is logged using `%s` ([link](https://github.com/DataDog/datadog-agent/blob/6d2789769d849f95c1310135cc7b82310425dc73/pkg/network/http/shared_libraries.go#L183)). With the aggregate retry error returned, the log message looks like:

```
2021-10-18 17:26:11 UTC | SYS-PROBE | ERROR | (pkg/network/http/shared_libraries.go:183 in register) | error registering library=/usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0: couldn’t attach new probe: All attempts fail:
```

The aggregate error ends up not properly continuing the error-unwrap chain to see the root cause, which makes it harder to understand what is going on. In this case, I artificially introduced an error using Delve, which shows the wrapped value that was given to the `log.Errorf` call:

```
(dlv) p err
error(*github.com/pkg/errors.withStack) *{
	error: error(*github.com/pkg/errors.withMessage) *{
		cause: error(github.com/avast/retry-go.Error) [
			*github.com/pkg/errors.fundamental {
				msg: “the probe must be initialized first”,
				stack: *github.com/pkg/errors.stack len: 12, cap: 32, [...],},
		],
		msg: “couldn’t attach new probe”,},
	stack: *github.com/pkg/errors.stack len: 21, cap: 32, [...],}
```

Once the changes in this PR are applied, the log message changes to:

```
2021-10-18 17:35:27 UTC | SYS-PROBE | ERROR | (pkg/network/http/shared_libraries.go:183 in register) | error registering library=/usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0: couldn’t attach new probe: the probe must be initialized first
```

Likewise, the error value no longer contains the aggregate error slice:

```
(dlv) p err
error(*github.com/pkg/errors.withStack) *{
	error: error(*github.com/pkg/errors.withMessage) *{
		cause: error(*github.com/pkg/errors.fundamental) *{
			msg: “the probe must be initialized first”,
			stack: *github.com/pkg/errors.stack len: 12, cap: 32, [...],},
		msg: “couldn’t attach new probe”,},
	stack: *github.com/pkg/errors.stack len: 21, cap: 32, [...],}
```

### Additional Notes

I made another PR with the same changes to `DataDog/ebpf-manager`: https://github.com/DataDog/ebpf/pull/56

Also, I'm not sure if any uses of this library might rely on returning the aggregate error, though I doubt it.

