### PR TITLE
Fix Probe copy

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -226,6 +226,7 @@ func (p *Probe) Copy() *Probe {
 		ProbeIdentificationPair: ProbeIdentificationPair{
 			UID:          p.UID,
 			EBPFFuncName: p.EBPFFuncName,
+			EBPFSection:  p.EBPFSection,
 		},
 		SyscallFuncName:  p.SyscallFuncName,
 		MatchFuncName:    p.MatchFuncName,


### PR DESCRIPTION
### What does this PR do?

This PR fixes a small typo in the `Probe.Copy()` method. If we don't copy the section name, the newly created probe can't be inserted as is in the manager.

### Motivation

Fix a bug in the library.
