### PR TITLE
Fix tail call with declared but not activated programs

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -361,12 +361,9 @@ func (p *Probe) init() error {
 
 	// Retrieve eBPF program if one isn't already set
 	if p.program == nil {
-		prog, ok := p.manager.collection.Programs[selector]
-		if !ok {
-			p.lastError = ErrUnknownSectionOrFuncName
+		if p.program, p.lastError = p.manager.getProbeProgram(p.ProbeIdentificationPair); p.lastError != nil {
 			return fmt.Errorf("couldn't find program %s: %w", selector, ErrUnknownSectionOrFuncName)
 		}
-		p.program = prog
 		p.checkPin = true
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a small bug that triggers a panic when you declare a `Probe` for a program that you're going to call through a tail call.