### PR TITLE
Fix the `ExcludedSections` feature and start non running probes on activated list update

### DIFF
--- a/examples/activated_probes/main.go
+++ b/examples/activated_probes/main.go
@@ -105,8 +105,8 @@ var options1 = manager.Options{
 				},
 			},
 		}},
-	ExcludedSections: []string{
-		"kprobe/exclude2",
+	ExcludedFunctions: []string{
+		"kprobe_exclude2",
 	},
 }
 
@@ -177,8 +177,8 @@ var options2 = manager.Options{
 			},
 		},
 	},
-	ExcludedSections: []string{
-		"kprobe/exclude",
+	ExcludedFunctions: []string{
+		"kprobe_exclude",
 	},
 }
 
@@ -280,6 +280,9 @@ func main() {
 	}
 
 	logrus.Println("updating activated probes of m3 (no error is expected)")
+	if err := m3.Init(recoverAssets()); err != nil {
+		logrus.Fatal(err)
+	}
 
 	mkdirID := manager.ProbeIdentificationPair{UID: "MyVFSMkdir2", EBPFSection: "kprobe/vfs_mkdir", EBPFFuncName: "kprobe_vfs_mkdir"}
 	if err := m3.UpdateActivatedProbes([]manager.ProbesSelector{

--- a/examples/activated_probes/main.go
+++ b/examples/activated_probes/main.go
@@ -290,7 +290,7 @@ func main() {
 			ProbeIdentificationPair: mkdirID,
 		},
 	}); err != nil {
-		logrus.Error(err)
+		logrus.Fatal(err)
 	}
 
 	vfsOpenID := manager.ProbeIdentificationPair{EBPFSection: "kprobe/vfs_opennnnnn", EBPFFuncName: "kprobe_vfs_opennnnnn"}

--- a/manager.go
+++ b/manager.go
@@ -1190,6 +1190,7 @@ func (m *Manager) UpdateActivatedProbes(selectors []ProbesSelector) error {
 		m.stateLock.Unlock()
 		return ErrManagerNotInitialized
 	}
+	defer m.stateLock.Unlock()
 
 	currentProbes := make(map[ProbeIdentificationPair]*Probe)
 	for _, p := range m.Probes {

--- a/manager.go
+++ b/manager.go
@@ -165,10 +165,10 @@ type Options struct {
 	// If the list is empty, all probes will be activated.
 	ActivatedProbes []ProbesSelector
 
-	// ExcludedSections - A list of sections that should not even be verified. This list overrides the ActivatedProbes
+	// ExcludedFunctions - A list of functions that should not even be verified. This list overrides the ActivatedProbes
 	// list: since the excluded sections aren't loaded in the kernel, all the probes using those sections will be
 	// deactivated.
-	ExcludedSections []string
+	ExcludedFunctions []string
 
 	// ConstantsEditor - Post-compilation constant edition. See ConstantEditor for more.
 	ConstantEditors []ConstantEditor
@@ -454,9 +454,9 @@ func (m *Manager) RenameProbeIdentificationPair(oldID ProbeIdentificationPair, n
 
 	if oldID.EBPFSection != newID.EBPFSection {
 		// edit the excluded sections
-		for i, section := range m.options.ExcludedSections {
-			if section == oldID.EBPFSection {
-				m.options.ExcludedSections[i] = newID.EBPFSection
+		for i, excludedFuncName := range m.options.ExcludedFunctions {
+			if excludedFuncName == oldID.EBPFFuncName {
+				m.options.ExcludedFunctions[i] = newID.EBPFFuncName
 			}
 		}
 	}
@@ -518,9 +518,7 @@ func (m *Manager) InitWithOptions(elf io.ReaderAt, options Options) error {
 	}
 
 	// Remove excluded sections
-	var excludedFuncName string
-	for _, excludedSection := range m.options.ExcludedSections {
-		_, excludedFuncName = parseEBPFPrefix(excludedSection)
+	for _, excludedFuncName := range m.options.ExcludedFunctions {
 		delete(m.collectionSpec.Programs, excludedFuncName)
 	}
 
@@ -1058,8 +1056,8 @@ func (m *Manager) getProbeProgramSpec(id ProbeIdentificationPair) (*ebpf.Program
 	if !ok {
 		// Check if the probe section is in the list of excluded sections
 		var excluded bool
-		for _, excludedSection := range m.options.ExcludedSections {
-			if excludedSection == id.EBPFSection {
+		for _, excludedFuncName := range m.options.ExcludedFunctions {
+			if excludedFuncName == id.EBPFFuncName {
 				excluded = true
 				break
 			}
@@ -1076,8 +1074,8 @@ func (m *Manager) getProbeProgram(id ProbeIdentificationPair) (*ebpf.Program, er
 	if !ok {
 		// Check if the probe section is in the list of excluded sections
 		var excluded bool
-		for _, excludedSection := range m.options.ExcludedSections {
-			if excludedSection == id.EBPFSection {
+		for _, excludedFuncName := range m.options.ExcludedFunctions {
+			if excludedFuncName == id.EBPFFuncName {
 				excluded = true
 				break
 			}
@@ -1169,8 +1167,8 @@ func (m *Manager) activateProbes() {
 				}
 			}
 		}
-		for _, p := range m.options.ExcludedSections {
-			if mProbe.EBPFSection == p {
+		for _, excludedFuncName := range m.options.ExcludedFunctions {
+			if mProbe.EBPFFuncName == excludedFuncName {
 				shouldActivate = false
 			}
 		}
@@ -1202,14 +1200,19 @@ func (m *Manager) UpdateActivatedProbes(selectors []ProbesSelector) error {
 	}
 
 	for id := range nextProbes {
-		if _, alreadyPresent := currentProbes[id]; alreadyPresent {
+		var probe *Probe
+		if currentProbe, alreadyPresent := currentProbes[id]; alreadyPresent {
 			delete(currentProbes, id)
+			probe = currentProbe
 		} else {
-			probe, found := m.GetProbe(id)
+			var found bool
+			probe, found = m.GetProbe(id)
 			if !found {
 				return fmt.Errorf("couldn't find program %s: %w", id, ErrUnknownSectionOrFuncName)
 			}
 			probe.Enabled = true
+		}
+		if !probe.IsRunning() {
 			if err := probe.Init(m); err != nil {
 				return err
 			}

--- a/manager.go
+++ b/manager.go
@@ -1185,6 +1185,12 @@ func (m *Manager) activateProbes() {
 
 // UpdateActivatedProbes - update the list of activated probes
 func (m *Manager) UpdateActivatedProbes(selectors []ProbesSelector) error {
+	m.stateLock.Lock()
+	if m.state < initialized {
+		m.stateLock.Unlock()
+		return ErrManagerNotInitialized
+	}
+
 	currentProbes := make(map[ProbeIdentificationPair]*Probe)
 	for _, p := range m.Probes {
 		if p.Enabled {

--- a/utils.go
+++ b/utils.go
@@ -482,32 +482,6 @@ func (fd *FD) Close() error {
 	return unix.Close(value)
 }
 
-func parseEBPFPrefix(section string) (string, string) {
-	splittedSection := strings.SplitN(section, "/", 2)
-	if len(splittedSection) <= 1 {
-		return "", section
-	}
-
-	switch splittedSection[0] {
-	case "cgroup", "cgroup_skb", "sk_skb":
-		// parse the second "/" to get the full prefix
-		splittedSection = strings.SplitN(section, "/", 3)
-		if len(splittedSection) <= 2 {
-			return splittedSection[0], splittedSection[1]
-		}
-		return fmt.Sprintf("%s/%s", splittedSection[0], splittedSection[1]), splittedSection[2]
-	case "tracepoint":
-		// parse the second "/" to get the function name
-		splittedSection = strings.SplitN(section, "/", 3)
-		if len(splittedSection) <= 2 {
-			return splittedSection[0], splittedSection[1]
-		}
-		return splittedSection[0], splittedSection[2]
-	default:
-		return splittedSection[0], splittedSection[1]
-	}
-}
-
 var (
 	// kprobePMUType is used to cache the kprobe PMY type value
 	kprobePMUType = struct {


### PR DESCRIPTION
### What does this PR do?

This PR does 2 things:
- This PR fixes the `ExcludedSections` feature which currently doesn't work, due to the probe selection mechanism from Cilium. The fix implies moving to `ExcludedFunctions`, which means that we cannot exclude entire sections anymore, we have to exclude eBPF programs by their function names.
- This PR ensures that non running probes are started if they are listed in the selector provided to `UpdateActivatedProbes()`.

### Motivation

When the manager fails to start, some probes might be enabled but not running. This means that they will fail validation if `UpdateActivatedProbes` doesn't restart them.