### PR TITLE
[TC classifier][XDP] Make sure the manager plays well with other services that might be using the clsact qdisc

### DIFF
--- a/err.go
+++ b/err.go
@@ -17,7 +17,7 @@ var (
 	ErrKprobeIDNotExist         = errors.New("kprobe id file doesn't exist")
 	ErrUprobeIDNotExist         = errors.New("uprobe id file doesn't exist")
 	ErrCloneProbeRequired       = errors.New("use CloneProbe to load 2 instances of the same program")
-	ErrInterfaceNotSet          = errors.New("interface not provided: at least one of Ifindex and Ifname must be set")
+	ErrInterfaceNotSet          = errors.New("interface not provided: at least one of IfIndex and IfName must be set")
 	ErrMapInitialized           = errors.New("map already initialized")
 	ErrMapNotInitialized        = errors.New("the map must be initialized first")
 	ErrMapNotRunning            = errors.New("the map is not running")

--- a/examples/program_router/main.go
+++ b/examples/program_router/main.go
@@ -13,7 +13,7 @@ var m = &manager.Manager{
 				EBPFSection:  "classifier/one",
 				EBPFFuncName: "one",
 			},
-			Ifname:           "enp0s3", // change this to the interface index connected to the internet
+			IfName:           "enp0s3", // change this to the interface index connected to the internet
 			NetworkDirection: manager.Egress,
 		},
 	},

--- a/examples/programs/tc/probe.go
+++ b/examples/programs/tc/probe.go
@@ -100,7 +100,7 @@ func bindataProbeO() (*asset, error) {
 		size: 1624,
 		md5checksum: "",
 		mode: os.FileMode(420),
-		modTime: time.Unix(1629886126, 0),
+		modTime: time.Unix(1640913018, 0),
 	}
 
 	a := &asset{bytes: bytes, info: info}

--- a/examples/programs/xdp/main.go
+++ b/examples/programs/xdp/main.go
@@ -13,7 +13,7 @@ var m = &manager.Manager{
 				EBPFSection:  "xdp/ingress",
 				EBPFFuncName: "ingress",
 			},
-			Ifindex:       2, // change this to the interface index connected to the internet
+			IfIndex:       2, // change this to the interface index connected to the internet
 			XDPAttachMode: manager.XdpAttachModeSkb,
 		},
 	},

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/vishvananda/netlink v1.1.0
+	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
 	golang.org/x/sys v0.0.0-20210921065528-437939a70204
 )

--- a/probe.go
+++ b/probe.go
@@ -3,19 +3,19 @@ package manager
 import (
 	"errors"
 	"fmt"
-	"net"
+	"io/fs"
 	"os"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	"github.com/DataDog/gopsutil/process"
 	"github.com/avast/retry-go"
 	"github.com/cilium/ebpf"
-	"github.com/florianl/go-tc"
-	"github.com/florianl/go-tc/core"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
@@ -36,19 +36,33 @@ const (
 	XdpAttachModeDrv XdpAttachMode = (1 << 2)
 	// XdpAttachModeHw suitable for NICs with hardware XDP support
 	XdpAttachModeHw XdpAttachMode = (1 << 3)
+	// DefaultTCFilterPriority is the default TC filter priority if none were given
+	DefaultTCFilterPriority = 50
 )
 
 type TrafficType uint32
 
-const (
-	Ingress = TrafficType(tc.HandleMinIngress)
-	Egress  = TrafficType(tc.HandleMinEgress)
-)
+func (tt TrafficType) String() string {
+	switch tt {
+	case Ingress:
+		return "ingress"
+	case Egress:
+		return "egress"
+	default:
+		return fmt.Sprintf("TrafficType(%d)", tt)
+	}
+}
 
 const (
+	Ingress          = TrafficType(netlink.HANDLE_MIN_INGRESS)
+	Egress           = TrafficType(netlink.HANDLE_MIN_EGRESS)
 	UnknownProbeType = ""
 	ProbeType        = "p"
 	RetProbeType     = "r"
+)
+
+var (
+	BpfFlagActDirect = uint32(1) // see TCA_BPF_FLAG_ACT_DIRECT
 )
 
 type ProbeIdentificationPair struct {
@@ -123,7 +137,11 @@ type Probe struct {
 	attachPID           int
 	attachRetryAttempt  uint
 	attachedWithDebugFS bool
-	systemWideID        uint32
+	systemWideID        int
+	programTag          string
+	link                netlink.Link
+	tcFilter            netlink.BpfFilter
+	tcClsActQdisc       netlink.Qdisc
 
 	// lastError - stores the last error that the probe encountered, it is used to surface a more useful error message
 	// when one of the validators (see Options.ActivatedProbes) fails.
@@ -201,15 +219,27 @@ type Probe struct {
 	// before they reach user space. The probe will be bound to the provided file descriptor
 	SocketFD int
 
-	// Ifindex - (TC classifier & XDP) Interface index used to identify the interface on which the probe will be
+	// IfIndex - (TC classifier & XDP) Interface index used to identify the interface on which the probe will be
 	// attached. If not set, fall back to Ifname.
-	Ifindex int32
+	IfIndex int
 
-	// Ifname - (TC Classifier & XDP) Interface name on which the probe will be attached.
-	Ifname string
+	// IfName - (TC Classifier & XDP) Interface name on which the probe will be attached.
+	IfName string
 
-	// IfindexNetns - (TC Classifier & XDP) Network namespace in which the network interface lives
-	IfindexNetns uint64
+	// IfIndexNetns - (TC Classifier & XDP) Network namespace in which the network interface lives. If this value is
+	// provided, then IfIndexNetnsID is required too.
+	// WARNING: it is up to the caller of "Probe.Start()" to close this netns handle. Failing to close this handle may
+	// lead to leaking the network namespace. This handle can be safely closed once "Probe.Start()" returns.
+	IfIndexNetns uint64
+
+	// IfIndexNetnsID - (TC Classifier & XDP) Network namespace ID associated of the IfIndexNetns handle. If this value
+	// is provided, then IfIndexNetns is required too.
+	// WARNING: it is up to the caller of "Probe.Start()" to call "manager.CleanupNetworkNamespace()" once the provided
+	// IfIndexNetnsID is no longer needed. Failing to call this cleanup function may lead to leaking the network
+	// namespace. Remember that "manager.CleanupNetworkNamespace()" will close the netlink socket opened with the netns
+	// handle provided above. If you want to start the probe again, you'll need to provide a new valid netns handle so
+	// that a new netlink socket can be created in that namespace.
+	IfIndexNetnsID uint32
 
 	// XDPAttachMode - (XDP) XDP attach mode. If not provided the kernel will automatically select the best available
 	// mode.
@@ -218,6 +248,13 @@ type Probe struct {
 	// NetworkDirection - (TC classifier) Network traffic direction of the classifier. Can be either Ingress or Egress. Keep
 	// in mind that if you are hooking on the host side of a virtuel ethernet pair, Ingress and Egress are inverted.
 	NetworkDirection TrafficType
+
+	// TCFilterPrio - (TC classifier) defines the priority of the classifier added to the clsact qdisc. Defaults to DefaultTCFilterPriority.
+	TCFilterPrio uint16
+
+	// TCFilterProtocol - (TC classifier) defines the protocol to match in order to trigger the classifier. Defaults to
+	// ETH_P_ALL.
+	TCFilterProtocol uint16
 
 	// SamplePeriod - (Perf event) This parameter defines when the perf_event eBPF program is triggered. When SamplePeriod > 0
 	// the program will be triggered every SamplePeriod events.
@@ -246,10 +283,6 @@ type Probe struct {
 
 	// perfEventCPUFDs - (Perf event) holds the FD of the perf_event program per CPU
 	perfEventCPUFDs []*FD
-
-	// tcObject - (TC classifier) TC object created when the classifier was attached. It will be reused to delete it on
-	// exit.
-	tcObject *tc.Object
 }
 
 // GetEBPFFuncName - Returns EBPFFuncName with the UID as a postfix if the Probe was copied
@@ -284,13 +317,16 @@ func (p *Probe) Copy() *Probe {
 		BinaryPath:         p.BinaryPath,
 		CGroupPath:         p.CGroupPath,
 		SocketFD:           p.SocketFD,
-		Ifindex:            p.Ifindex,
-		Ifname:             p.Ifname,
-		IfindexNetns:       p.IfindexNetns,
+		IfIndex:            p.IfIndex,
+		IfName:             p.IfName,
+		IfIndexNetns:       p.IfIndexNetns,
+		IfIndexNetnsID:     p.IfIndexNetnsID,
 		XDPAttachMode:      p.XDPAttachMode,
 		NetworkDirection:   p.NetworkDirection,
 		ProbeRetry:         p.ProbeRetry,
 		ProbeRetryDelay:    p.ProbeRetryDelay,
+		TCFilterProtocol:   p.TCFilterProtocol,
+		TCFilterPrio:       p.TCFilterPrio,
 	}
 }
 
@@ -422,14 +458,19 @@ func (p *Probe) init() error {
 		p.HookFuncName = p.programSpec.AttachTo
 	}
 
-	// Resolve interface index if one is provided
-	if p.Ifindex == 0 && p.Ifname != "" {
-		inter, err := net.InterfaceByName(p.Ifname)
-		if err != nil {
-			p.lastError = err
-			return fmt.Errorf("couldn't find interface %v: %w", p.Ifname, err)
-		}
-		p.Ifindex = int32(inter.Index)
+	// resolve netns ID from netns handle
+	if p.IfIndexNetns == 0 && p.IfIndexNetnsID != 0 || p.IfIndexNetns != 0 && p.IfIndexNetnsID == 0 {
+		return fmt.Errorf("both IfIndexNetns and IfIndexNetnsID are required if one is provided (IfIndexNetns: %d IfIndexNetnsID: %d)", p.IfIndexNetns, p.IfIndexNetnsID)
+	}
+
+	// set default TC classifier priority
+	if p.TCFilterPrio == 0 {
+		p.TCFilterPrio = DefaultTCFilterPriority
+	}
+
+	// set default TC classifier protocol
+	if p.TCFilterProtocol == 0 {
+		p.TCFilterProtocol = unix.ETH_P_ALL
 	}
 
 	// Default max active value
@@ -455,9 +496,10 @@ func (p *Probe) init() error {
 	if p.program != nil {
 		programInfo, err := p.program.Info()
 		if err == nil {
+			p.programTag = programInfo.Tag
 			id, available := programInfo.ID()
 			if available {
-				p.systemWideID = uint32(id)
+				p.systemWideID = int(id)
 			}
 		}
 	}
@@ -465,6 +507,41 @@ func (p *Probe) init() error {
 	// update probe state
 	p.state = initialized
 	return nil
+}
+
+// resolveLink - Resolves the Probe's network interface
+func (p *Probe) resolveLink() (netlink.Link, error) {
+	if p.link != nil {
+		return p.link, nil
+	}
+
+	// get a netlink socket in the probe network namespace
+	ntl, err := p.getNetlinkSocket()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.IfIndex > 0 {
+		p.link, err = ntl.Sock.LinkByIndex(p.IfIndex)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't resolve interface with IfIndex %d in namespace %d: %w", p.IfIndex, p.IfIndexNetnsID, err)
+		}
+	} else if len(p.IfName) > 0 {
+		p.link, err = ntl.Sock.LinkByName(p.IfName)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't resolve interface with IfName %s in namespace %d: %w", p.IfName, p.IfIndexNetnsID, err)
+		}
+	} else {
+		return nil, ErrInterfaceNotSet
+	}
+
+	attrs := p.link.Attrs()
+	if attrs != nil {
+		p.IfIndex = attrs.Index
+		p.IfName = attrs.Name
+	}
+
+	return p.link, nil
 }
 
 // Attach - Attaches the probe to the right hook point in the kernel depending on the program type and the provided
@@ -499,6 +576,9 @@ func (p *Probe) attach() error {
 		}
 		return ErrProbeNotInitialized
 	}
+
+	// TODO: replace with the value of the like at {HOST_PROC}/self
+	p.attachPID = os.Getpid()
 
 	// Per program type start
 	var err error
@@ -653,9 +733,17 @@ func (p *Probe) reset() {
 	p.attachRetryAttempt = 0
 	p.attachedWithDebugFS = false
 	p.systemWideID = 0
+	p.programTag = ""
+	p.tcFilter = netlink.BpfFilter{}
+	p.tcClsActQdisc = nil
 }
 
-// attachWithKprobeEvents attach kprobes using the kprobes events ABI
+// getNetlinkSocket returns a netlink socket in the probe network namespace
+func (p *Probe) getNetlinkSocket() (*NetlinkSocket, error) {
+	return p.manager.getNetlinkSocket(p.IfIndexNetns, p.IfIndexNetnsID)
+}
+
+// attachWithKprobeEvents attaches the kprobe using the kprobes_events ABI
 func (p *Probe) attachWithKprobeEvents() error {
 	// Prepare kprobe_events line parameters
 	var maxActiveStr string
@@ -700,8 +788,6 @@ func (p *Probe) attachKprobe() error {
 		// this might actually be a UProbe
 		return p.attachUprobe()
 	}
-
-	p.attachPID = os.Getpid()
 
 	// currently the perf event open ABI doesn't allow to specify the max active parameter
 	if p.KProbeMaxActive > 0 && p.GetKprobeType() == RetProbeType {
@@ -776,8 +862,6 @@ func (p *Probe) attachUprobe() error {
 	var err error
 
 	// Prepare uprobe_events line parameters
-	p.attachPID = os.Getpid()
-
 	if p.GetUprobeType() == UnknownProbeType {
 		// unknown type
 		return fmt.Errorf("program type unrecognized in %s: %w", p.ProbeIdentificationPair, ErrSectionFormat)
@@ -892,78 +976,113 @@ func (p *Probe) detachSocket() error {
 	return sockDetach(p.SocketFD, p.program.FD())
 }
 
+func (p *Probe) buildTCClsActQdisc() netlink.Qdisc {
+	if p.tcClsActQdisc == nil {
+		p.tcClsActQdisc = &netlink.GenericQdisc{
+			QdiscType: "clsact",
+			QdiscAttrs: netlink.QdiscAttrs{
+				LinkIndex: p.IfIndex,
+				Handle:    netlink.MakeHandle(0xffff, 0),
+				Parent:    netlink.HANDLE_INGRESS,
+			},
+		}
+	}
+	return p.tcClsActQdisc
+}
+
+func (p *Probe) buildTCFilter() (netlink.BpfFilter, error) {
+	if p.tcFilter.FilterAttrs.LinkIndex == 0 {
+		var filterName string
+		filterName, err := GenerateTCFilterName(p.UID, p.EBPFSection, p.attachPID)
+		if err != nil {
+			return p.tcFilter, fmt.Errorf("couldn't create TC filter for %v: %w", p.ProbeIdentificationPair, err)
+		}
+
+		p.tcFilter = netlink.BpfFilter{
+			FilterAttrs: netlink.FilterAttrs{
+				LinkIndex: p.IfIndex,
+				Parent:    uint32(p.NetworkDirection),
+				Priority:  p.TCFilterPrio,
+				Protocol:  p.TCFilterProtocol,
+			},
+			Fd:           p.program.FD(),
+			Name:         filterName,
+			DirectAction: true,
+		}
+	}
+	return p.tcFilter, nil
+}
+
 // attachTCCLS - Attaches the probe to its TC classifier hook point
 func (p *Probe) attachTCCLS() error {
 	var err error
-	// Make sure Ifindex is properly set
-	if p.Ifindex == 0 && p.Ifname == "" {
+	// Resolve Probe's interface
+	if _, err = p.resolveLink(); err != nil {
 		return ErrInterfaceNotSet
 	}
 
 	// Recover the netlink socket of the interface from the manager
-	ntl, ok := p.manager.netlinkCache[netlinkCacheKey{p.Ifindex, p.IfindexNetns}]
-	if !ok {
-		// Set up new netlink connection
-		ntl, err = p.manager.newNetlinkConnection(p.Ifindex, p.IfindexNetns)
-		if err != nil {
-			return err
-		}
+	ntl, err := p.getNetlinkSocket()
+	if err != nil {
+		return err
 	}
 
 	// Create a Qdisc for the provided interface
-	qdisc := &tc.Object{
-		Msg: tc.Msg{
-			Family:  unix.AF_UNSPEC,
-			Ifindex: uint32(p.Ifindex),
-			Handle:  core.BuildHandle(tc.HandleRoot, 0x0000),
-			Parent:  tc.HandleIngress,
-			Info:    0,
-		},
-		Attribute: tc.Attribute{
-			Kind: "clsact",
-		},
-	}
-
-	// Add the Qdisc
-	err = ntl.rtNetlink.Qdisc().Add(qdisc)
+	err = ntl.Sock.QdiscAdd(p.buildTCClsActQdisc())
 	if err != nil {
-		if err.Error() != "netlink receive: file exists" {
-			return fmt.Errorf("couldn't add a \"clsact\" qdisc to interface %v: %w", p.Ifindex, err)
+		if errors.Is(err, fs.ErrExist) {
+			// cleanup previous TC filters if necessary
+			if err = p.cleanupTCFilters(ntl); err != nil {
+				return fmt.Errorf("couldn't clean up existing \"clsact\" qdisc filters for %s[%d]: %w", p.IfName, p.IfIndex, err)
+			}
+		} else {
+			return fmt.Errorf("couldn't add a \"clsact\" qdisc to interface %s[%d]: %w", p.IfName, p.IfIndex, err)
 		}
 	}
 
 	// Create qdisc filter
-	fd := uint32(p.program.FD())
-	flag := uint32(1)
-	filter := tc.Object{
-		Msg: tc.Msg{
-			Family:  unix.AF_UNSPEC,
-			Ifindex: uint32(p.Ifindex),
-			Handle:  0,
-			Parent:  core.BuildHandle(tc.HandleRoot, uint32(p.NetworkDirection)),
-			Info:    0x300,
-		},
-		Attribute: tc.Attribute{
-			Kind: "bpf",
-
-			BPF: &tc.Bpf{
-				FD:    &fd,
-				Name:  &p.EBPFSection,
-				Flags: &flag,
-			},
-		},
+	_, err = p.buildTCFilter()
+	if err != nil {
+		return err
+	}
+	if err = ntl.Sock.FilterAdd(&p.tcFilter); err != nil {
+		return fmt.Errorf("couldn't add a %v filter to interface %s[%d]: %v", p.NetworkDirection, p.IfName, p.IfIndex, err)
 	}
 
-	// Add qdisc filter
-	if err := ntl.rtNetlink.Filter().Add(&filter); err != nil {
-		return fmt.Errorf("couldn't add a %v filter to interface %v: %v", p.NetworkDirection, p.Ifindex, err)
+	// retrieve filter handle
+	resp, err := ntl.Sock.FilterList(p.link, p.tcFilter.Parent)
+	if err != nil {
+		return fmt.Errorf("couldn't list filters of interface %s[%d]: %v", p.IfName, p.IfIndex, err)
 	}
-	p.tcObject = qdisc
-	ntl.schedClsCount++
+
+	var found bool
+	bpfType := (&netlink.BpfFilter{}).Type()
+	for _, elem := range resp {
+		if elem.Type() != bpfType {
+			continue
+		}
+
+		bpfFilter, ok := elem.(*netlink.BpfFilter)
+		if !ok {
+			continue
+		}
+
+		// we can't test the equality of the program tag, there is a bug in the netlink library.
+		// See https://github.com/vishvananda/netlink/issues/722
+		if bpfFilter.Id == p.systemWideID && strings.Contains(p.programTag, bpfFilter.Tag) { //
+			found = true
+			p.tcFilter.Handle = bpfFilter.Handle
+		}
+	}
+	if !found {
+		return fmt.Errorf("couldn't create TC filter for %v: filter not found", p.ProbeIdentificationPair)
+	}
+	ntl.TCFilterCount[p.IfIndex]++
+
 	return nil
 }
 
-func (p *Probe) IsTCCLSActive() bool {
+func (p *Probe) IsTCFilterActive() bool {
 	p.stateLock.Lock()
 	defer p.stateLock.Unlock()
 	if p.state != running || !p.Enabled {
@@ -974,32 +1093,31 @@ func (p *Probe) IsTCCLSActive() bool {
 	}
 
 	// Recover the netlink socket of the interface from the manager
-	var err error
-	ntl, ok := p.manager.netlinkCache[netlinkCacheKey{p.Ifindex, p.IfindexNetns}]
-	if !ok {
-		// Set up new netlink connection
-		ntl, err = p.manager.newNetlinkConnection(p.Ifindex, p.IfindexNetns)
-		if err != nil {
-			return false
-		}
-	}
-
-	msg := tc.Msg{
-		Family:  unix.AF_UNSPEC,
-		Ifindex: uint32(p.Ifindex),
-		Parent:  core.BuildHandle(tc.HandleRoot, uint32(p.NetworkDirection)),
-	}
-
-	resp, err := ntl.rtNetlink.Filter().Get(&msg)
+	ntl, err := p.getNetlinkSocket()
 	if err != nil {
 		return false
 	}
 
+	resp, err := ntl.Sock.FilterList(p.link, p.tcFilter.Parent)
+	if err != nil {
+		return false
+	}
+
+	bpfType := (&netlink.BpfFilter{}).Type()
 	for _, elem := range resp {
-		if elem.Attribute.BPF != nil {
-			if elem.Attribute.BPF.ID != nil && *elem.Attribute.BPF.ID == p.systemWideID {
-				return true
-			}
+		if elem.Type() != bpfType {
+			continue
+		}
+
+		bpfFilter, ok := elem.(*netlink.BpfFilter)
+		if !ok {
+			continue
+		}
+
+		// we can't test the equality of the program tag, there is a bug in the netlink library.
+		// See https://github.com/vishvananda/netlink/issues/722
+		if bpfFilter.Id == p.systemWideID && strings.Contains(p.programTag, bpfFilter.Tag) {
+			return true
 		}
 	}
 	return false
@@ -1008,53 +1126,134 @@ func (p *Probe) IsTCCLSActive() bool {
 // detachTCCLS - Detaches the probe from its TC classifier hook point
 func (p *Probe) detachTCCLS() error {
 	// Recover the netlink socket of the interface from the manager
-	ntl, ok := p.manager.netlinkCache[netlinkCacheKey{p.Ifindex, p.IfindexNetns}]
-	if !ok {
-		return fmt.Errorf("couldn't find qdisc from which the probe %v was meant to be detached", p.ProbeIdentificationPair)
+	ntl, err := p.getNetlinkSocket()
+	if err != nil {
+		return err
 	}
 
-	if ntl.schedClsCount >= 2 {
-		ntl.schedClsCount--
-		// another classifier is still using the qdisc, do not delete it yet
+	// delete the current filter
+	if err = ntl.Sock.FilterDel(&p.tcFilter); err != nil {
+		// the device or the filter might already be gone, ignore the error if that's the case
+		if !errors.Is(err, syscall.ENODEV) && !errors.Is(err, syscall.ENOENT) {
+			return fmt.Errorf("couldn't remove TC classifier %v: %w", p.ProbeIdentificationPair, err)
+		}
+	}
+	ntl.TCFilterCount[p.IfIndex]--
+
+	// check if the qdisc should be deleted
+	if ntl.TCFilterCount[p.IfIndex] >= 1 {
+		// at list one of our classifiers is still using it
+		return nil
+	}
+	delete(ntl.TCFilterCount, p.IfIndex)
+
+	// check if someone else is using the clsact qdisc on ingress
+	resp, err := ntl.Sock.FilterList(p.link, netlink.HANDLE_MIN_INGRESS)
+	if err != nil || err == nil && len(resp) > 0 {
+		// someone is still using it
 		return nil
 	}
 
-	// Delete qdisc
-	err := ntl.rtNetlink.Qdisc().Delete(p.tcObject)
-	if err != nil {
-		return fmt.Errorf("couldn't detach TC classifier of probe %v: %w", p.ProbeIdentificationPair, err)
+	// check on egress
+	resp, err = ntl.Sock.FilterList(p.link, netlink.HANDLE_MIN_EGRESS)
+	if err != nil || err == nil && len(resp) > 0 {
+		// someone is still using it
+		return nil
+	}
+
+	// delete qdisc
+	if err = ntl.Sock.QdiscDel(p.buildTCClsActQdisc()); err != nil {
+		// the device might already be gone, ignore the error if that's the case
+		if !errors.Is(err, syscall.ENODEV) {
+			return fmt.Errorf("couldn't remove clsact qdisc: %w", err)
+		}
 	}
 	return nil
 }
 
+// cleanupTCFilters - Cleans up existing TC Filters by removing entries of known UIDs, that they're not used anymore.
+//
+// Previous instances of this manager might have been killed unexpectedly. When this happens, TC filters are not cleaned
+// up properly and can grow indefinitely. To prevent this, start by cleaning up the TC filters of previous managers that
+// are not running anymore.
+func (p *Probe) cleanupTCFilters(ntl *NetlinkSocket) error {
+	// build the pattern to look for in the TC filters name
+	pattern, err := regexp.Compile(fmt.Sprintf(`.*(%s)_([0-9]*)`, p.UID))
+	if err != nil {
+		return fmt.Errorf("filter name pattern generation failed: %w", err)
+	}
+
+	resp, err := ntl.Sock.FilterList(p.link, uint32(p.NetworkDirection))
+	if err != nil {
+		return err
+	}
+
+	var deleteErr error
+	bpfType := (&netlink.BpfFilter{}).Type()
+	for _, elem := range resp {
+		if elem.Type() != bpfType {
+			continue
+		}
+
+		bpfFilter, ok := elem.(*netlink.BpfFilter)
+		if !ok {
+			continue
+		}
+
+		match := pattern.FindStringSubmatch(bpfFilter.Name)
+		if len(match) < 3 {
+			continue
+		}
+
+		// check if the manager that loaded this TC filter is still up
+		var pid int
+		pid, err = strconv.Atoi(match[2])
+		if err != nil {
+			continue
+		}
+
+		// this short sleep is used to avoid a CPU spike (5s ~ 60k * 80 microseconds)
+		time.Sleep(80 * time.Microsecond)
+
+		_, err = process.NewProcess(int32(pid))
+		if err == nil {
+			continue
+		}
+
+		// remove this filter
+		deleteErr = ConcatErrors(deleteErr, ntl.Sock.FilterDel(elem))
+	}
+	return deleteErr
+}
+
 // attachXDP - Attaches the probe to an interface with an XDP hook point
 func (p *Probe) attachXDP() error {
-	// Lookup interface
-	link, err := netlink.LinkByIndex(int(p.Ifindex))
-	if err != nil {
-		return fmt.Errorf("couldn't retrieve interface %v: %w", p.Ifindex, err)
+	var err error
+	// Resolve Probe's interface
+	if _, err = p.resolveLink(); err != nil {
+		return ErrInterfaceNotSet
 	}
 
 	// Attach program
-	err = netlink.LinkSetXdpFdWithFlags(link, p.program.FD(), int(p.XDPAttachMode))
+	err = netlink.LinkSetXdpFdWithFlags(p.link, p.program.FD(), int(p.XDPAttachMode))
 	if err != nil {
-		return fmt.Errorf("couldn't attach XDP program %v to interface %v: %w", p.ProbeIdentificationPair, p.Ifindex, err)
+		return fmt.Errorf("couldn't attach XDP program %v to interface %v: %w", p.ProbeIdentificationPair, p.IfIndex, err)
 	}
 	return nil
 }
 
 // detachXDP - Detaches the probe from its XDP hook point
 func (p *Probe) detachXDP() error {
-	// Lookup interface
-	link, err := netlink.LinkByIndex(int(p.Ifindex))
-	if err != nil {
-		return fmt.Errorf("couldn't retrieve interface %v: %w", p.Ifindex, err)
+	var err error
+	// Resolve Probe's interface
+	if _, err = p.resolveLink(); err != nil {
+		return ErrInterfaceNotSet
 	}
 
 	// Detach program
-	err = netlink.LinkSetXdpFdWithFlags(link, -1, int(p.XDPAttachMode))
+	err = netlink.LinkSetXdpFdWithFlags(p.link, -1, int(p.XDPAttachMode))
 	if err != nil {
-		return fmt.Errorf("couldn't detach XDP program %v from interface %v: %w", p.ProbeIdentificationPair, p.Ifindex, err)
+		return fmt.Errorf("couldn't detach XDP program %v from interface %v: %w", p.ProbeIdentificationPair, p.IfIndex, err)
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR ensures that the manager plays well with other services that might be using the `clsact` qdisc. The point here is to make sure that it won't touch any BPF filters that don't need to be touched, as well as perform a proper cleanup on start up if a previous manager was abruptly killed.

This PR cleans up the netlink socket cache to prevent leaking network namespaces. Important comments were added when actions are expected from the user of the manager.

```golang
type Probe struct {
        [...]

	// IfIndexNetns - (TC Classifier & XDP) Network namespace in which the network interface lives. If this value is
	// provided, then IfIndexNetnsID is required too.
	// WARNING: it is up to the caller of "Probe.Start()" to close this netns handle. Failing to close this handle may
	// lead to leaking the network namespace. This handle can be safely closed once "Probe.Start()" returns.
	IfIndexNetns uint64

	// IfIndexNetnsID - (TC Classifier & XDP) Network namespace ID associated of the IfIndexNetns handle. If this value
	// is provided, then IfIndexNetns is required too.
	// WARNING: it is up to the caller of "Probe.Start()" to call "manager.CleanupNetworkNamespace()" once the provided
	// IfIndexNetnsID is no longer needed. Failing to call this cleanup function may lead to leaking the network
	// namespace. Remember that "manager.CleanupNetworkNamespace()" will close the netlink socket opened with the netns
	// handle provided above. If you want to start the probe again, you'll need to provide a new valid netns handle so
	// that a new netlink socket can be created in that namespace.
	IfIndexNetnsID uint32

        [...]
}
```

```golang
// CleanupNetworkNamespace - Cleans up all references to the provided network namespace within the manager. This means
// that any TC classifier or XDP probe in that network namespace will be stopped and all opened netlink socket in that
// namespace will be closed.
// WARNING: Don't forget to call this method if you've provided a IfindexNetns and IfindexNetnsID to one of the probes
// of this manager. Failing to call this cleanup function may lead to leaking the network namespace. Only call this
// function when you're sure that the manager no longer needs to perform anything in the provided network namespace (or
// else call NewNetlinkConnection first).
func (m *Manager) CleanupNetworkNamespace(netnsID uint32) error {
        [...]
}
```

Two new options were also added to the TC classifier probe type:

```golang
type Probe struct {
        [...]

	// TCFilterPrio - (TC classifier) defines the priority of the classifier added to the clsact qdisc. Defaults to 50.
	TCFilterPrio uint16

	// TCFilterProtocol - (TC classifier) defines the protocol to match in order to trigger the classifier. Defaults to
	// ETH_P_ALL.
	TCFilterProtocol uint16

        [...]
}
```

### Describe how to test your changes

The TC example was updated to test the new changes.