### PR TITLE
[Probe.attachPID] Fix process PID namespace bug

### DIFF
--- a/examples/programs/kprobe/ebpf/main.c
+++ b/examples/programs/kprobe/ebpf/main.c
@@ -14,10 +14,10 @@ int BPF_KPROBE(kprobe_vfs_mkdir, struct user_namespace *mnt_userns)
     return 0;
 };
 
-SEC("kprobe/utimes_common")
-int kprobe_utimes_common(struct pt_regs *ctx)
+SEC("kretprobe/utimes_common")
+int kretprobe_utimes_common(struct pt_regs *ctx)
 {
-    bpf_printk("utimes_common\n");
+    bpf_printk("utimes_common return\n");
     return 0;
 };
 

--- a/examples/programs/kprobe/main.go
+++ b/examples/programs/kprobe/main.go
@@ -22,10 +22,11 @@ var m = &manager.Manager{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "UtimesCommon",
-				EBPFSection:  "kprobe/utimes_common",
-				EBPFFuncName: "kprobe_utimes_common",
+				EBPFSection:  "kretprobe/utimes_common",
+				EBPFFuncName: "kretprobe_utimes_common",
 			},
-			MatchFuncName: "utimes",
+			MatchFuncName:   "utimes",
+			KProbeMaxActive: 100,
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
@@ -37,7 +38,6 @@ var m = &manager.Manager{
 				EBPFFuncName: "kretprobe_mkdirat",
 			},
 			SyscallFuncName: "mkdirat",
-			KProbeMaxActive: 100,
 		},
 	},
 }

--- a/manager.go
+++ b/manager.go
@@ -1737,7 +1737,7 @@ func (m *Manager) cleanupTracefs() error {
 
 	// clean up kprobe_events
 	var cleanUpErrors *multierror.Error
-	pidMask := map[int]procMask{os.Getpid(): Running}
+	pidMask := map[int]procMask{Getpid(): Running}
 	cleanUpErrors = multierror.Append(cleanUpErrors, cleanupKprobeEvents(pattern, pidMask))
 	cleanUpErrors = multierror.Append(cleanUpErrors, cleanupUprobeEvents(pattern, pidMask))
 	if cleanUpErrors.Len() == 0 {

--- a/probe.go
+++ b/probe.go
@@ -577,8 +577,7 @@ func (p *Probe) attach() error {
 		return ErrProbeNotInitialized
 	}
 
-	// TODO: replace with the value of the like at {HOST_PROC}/self
-	p.attachPID = os.Getpid()
+	p.attachPID = Getpid()
 
 	// Per program type start
 	var err error

--- a/utils.go
+++ b/utils.go
@@ -606,3 +606,40 @@ func getRetProbeBit(eventType string) (uint64, error) {
 		return 0, fmt.Errorf("unknown event type %s", eventType)
 	}
 }
+
+//GetEnv retrieves the environment variable key. If it does not exist it returns the default.
+func GetEnv(key string, dfault string, combineWith ...string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		value = dfault
+	}
+
+	switch len(combineWith) {
+	case 0:
+		return value
+	case 1:
+		return filepath.Join(value, combineWith[0])
+	default:
+		all := make([]string, len(combineWith)+1)
+		all[0] = value
+		copy(all[1:], combineWith)
+		return filepath.Join(all...)
+	}
+}
+
+// HostProc returns joins the provided path with the host /proc directory
+func HostProc(combineWith ...string) string {
+	return GetEnv("HOST_PROC", "/proc", combineWith...)
+}
+
+// Getpid returns the current process ID in the host namespace if $HOST_PROC is defined, the pid in the current namespace
+// otherwise
+func Getpid() int {
+	p, err := os.Readlink(HostProc("/self"))
+	if err == nil {
+		if pid, err := strconv.ParseInt(p, 10, 32); err == nil {
+			return int(pid)
+		}
+	}
+	return os.Getpid()
+}


### PR DESCRIPTION
### What does this PR do?

This PR ensures that when we resolve the PID of the manager, we start by looking at the host proc filesystem in order to resolve the PID of the current task in the context of the root PID namespace (instead of the container PID namespace in which the manager might be running). This PR expects the host /proc filesystem to be mounted at a directory specified in $HOST_PROC. This follows the deployment convention of the Datadog Agent.

### Motivation

We currently use the namespaced PID to write events in `kprobe_events` and TC BPF filter names. This means that we won't be able to correctly detect if two Datadog Agents are running simultaneously: the last agent to start will never be able to resolve the PID of the first Datadog Agent, and will therefore always try to remove the hook points of the first manager (if the two agents are running in different PID namespaces).
