### PR TITLE
[uprobe] Enable uprobe pid filtering

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -221,7 +221,7 @@ type Probe struct {
 	// unix.PERF_TYPE_HARDWARE and unix.PERF_TYPE_SOFTWARE
 	PerfEventType int
 
-	// PerfEventPID - (Perf event) This parameter defines the PID for which the perf_event program should be triggered.
+	// PerfEventPID - (Perf event, uprobes) This parameter defines the PID for which the program should be triggered.
 	// Do not set this value to monitor the whole host.
 	PerfEventPID int
 

--- a/probe.go
+++ b/probe.go
@@ -667,7 +667,7 @@ func (p *Probe) attachWithKprobeEvents() error {
 	}
 
 	// create perf event FD
-	p.perfEventFD, err = perfEventOpenTracingEvent(kprobeID)
+	p.perfEventFD, err = perfEventOpenTracingEvent(kprobeID, -1)
 	if err != nil {
 		return fmt.Errorf("couldn't open perf event FD for %s: %w", p.ProbeIdentificationPair, err)
 	}
@@ -747,7 +747,7 @@ func (p *Probe) attachTracepoint() error {
 	}
 
 	// Hook the eBPF program to the tracepoint
-	p.perfEventFD, err = perfEventOpenTracingEvent(tracepointID)
+	p.perfEventFD, err = perfEventOpenTracingEvent(tracepointID, -1)
 	if err != nil {
 		return fmt.Errorf("couldn't enable tracepoint %s: %w", p.ProbeIdentificationPair, err)
 	}
@@ -794,7 +794,7 @@ func (p *Probe) attachUprobe() error {
 	}
 
 	// Try to use the perf_event_open API first (e12f03d "perf/core: Implement the 'perf_kprobe' PMU")
-	p.perfEventFD, err = perfEventOpenPMU(p.BinaryPath, int(p.UprobeOffset), -1, "uprobe", p.GetUprobeType() == "r", 0)
+	p.perfEventFD, err = perfEventOpenPMU(p.BinaryPath, int(p.UprobeOffset), p.PerfEventPID, "uprobe", p.GetUprobeType() == "r", 0)
 	if err != nil {
 		// fallback to debugfs
 		var uprobeID int
@@ -804,7 +804,7 @@ func (p *Probe) attachUprobe() error {
 		}
 
 		// Activate perf event
-		p.perfEventFD, err = perfEventOpenTracingEvent(uprobeID)
+		p.perfEventFD, err = perfEventOpenTracingEvent(uprobeID, p.PerfEventPID)
 		if err != nil {
 			return fmt.Errorf("couldn't enable uprobe %s: %w", p.ProbeIdentificationPair, err)
 		}

--- a/syscalls.go
+++ b/syscalls.go
@@ -58,7 +58,7 @@ func perfEventOpenPMU(name string, offset, pid int, eventType string, retProbe b
 		attr.Ext1 = uint64(uintptr(unsafe.Pointer(namePtr))) // Uprobe path
 		attr.Ext2 = uint64(offset)                           // Uprobe offset
 		// PID filter is only possible for uprobe events
-		if pid < 0 {
+		if pid <= 0 {
 			pid = -1
 		}
 	}
@@ -82,7 +82,10 @@ func perfEventOpenPMU(name string, offset, pid int, eventType string, retProbe b
 	return NewFD(uint32(efd)), nil
 }
 
-func perfEventOpenTracingEvent(probeID int) (*FD, error) {
+func perfEventOpenTracingEvent(probeID int, pid int) (*FD, error) {
+	if pid <= 0 {
+		pid = -1
+	}
 	attr := unix.PerfEventAttr{
 		Type:        unix.PERF_TYPE_TRACEPOINT,
 		Sample_type: unix.PERF_SAMPLE_RAW,
@@ -91,7 +94,7 @@ func perfEventOpenTracingEvent(probeID int) (*FD, error) {
 		Config:      uint64(probeID),
 	}
 	attr.Size = uint32(unsafe.Sizeof(attr))
-	return perfEventOpenRaw(&attr, -1, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
+	return perfEventOpenRaw(&attr, pid, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
 }
 
 func perfEventOpenRaw(attr *unix.PerfEventAttr, pid int, cpu int, groupFd int, flags int) (*FD, error) {


### PR DESCRIPTION
### What does this PR do?

It is possible to request that a Uprobe be triggered for only one specific process. Instead of triggering on all instances of the binary, you can specify the `pid` of the traced process in `Probe.PerfEventPID`.

### Motivation

Improve the performance of a Uprobe to reduce the impact of Uprobes on the system.