### PR TITLE
[UpdateActivatedList] fix update activated list deadlock

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1263,7 +1263,7 @@ func (m *Manager) UpdateActivatedProbes(selectors []ProbesSelector) error {
 
 	if validationErrs != nil {
 		// Clean up
-		_ = m.Stop(CleanInternal)
+		_ = m.stop(CleanInternal)
 		return fmt.Errorf("probes activation validation failed: %w", validationErrs)
 	}
 

--- a/perf.go
+++ b/perf.go
@@ -131,7 +131,7 @@ func (m *PerfMap) Start() error {
 func (m *PerfMap) Stop(cleanup MapCleanupType) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.state < running {
+	if m.state < paused {
 		return nil
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes 2 deadlocks in the manager that may happen when you try to update the list of activated probes, with a list of probes that contains a validator error, after pausing an active perf map. The manager will try to lock the manager state twice (because of `m.Stop()`), and even if you call `m.stop()`, it will deadlock while waiting for the manager wait group, because the perf map is in `pause` state, which is below `running`, which means that you won't close the perf reader ... which will never release the perf map goroutine ... which will never call `Done()` on the manager waitgroup ...

### Motivation

Fix 2 deadlocks.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
