### PR TITLE
[UpdateActivatedList] Do not return error on probe Attach error, use activated list

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1239,9 +1239,9 @@ func (m *Manager) UpdateActivatedProbes(selectors []ProbesSelector) error {
 			if err := probe.Init(m); err != nil {
 				return err
 			}
-			if err := probe.Attach(); err != nil {
-				return err
-			}
+			// ignore the error, they are already collected per probes and will be surfaced by the
+			// activation validators if needed.
+			_ = probe.Attach()
 		}
 	}
 

--- a/probe.go
+++ b/probe.go
@@ -704,14 +704,14 @@ func (p *Probe) attachKprobe() error {
 	p.attachPID = os.Getpid()
 
 	// currently the perf event open ABI doesn't allow to specify the max active parameter
-	if p.KProbeMaxActive > 0 {
+	if p.KProbeMaxActive > 0 && p.GetKprobeType() == RetProbeType {
 		if err = p.attachWithKprobeEvents(); err != nil {
-			if p.perfEventFD, err = perfEventOpenPMU(p.HookFuncName, 0, -1, "kprobe", p.GetKprobeType() == "r", 0); err != nil {
+			if p.perfEventFD, err = perfEventOpenPMU(p.HookFuncName, 0, -1, "kprobe", true, 0); err != nil {
 				return err
 			}
 		}
 	} else {
-		if p.perfEventFD, err = perfEventOpenPMU(p.HookFuncName, 0, -1, "kprobe", p.GetKprobeType() == "r", 0); err != nil {
+		if p.perfEventFD, err = perfEventOpenPMU(p.HookFuncName, 0, -1, "kprobe", false, 0); err != nil {
 			if err = p.attachWithKprobeEvents(); err != nil {
 				return err
 			}


### PR DESCRIPTION
### What does this PR do?

While updating the list of activated probes, some `ProbesSelector` might select probes that are not available on the current host. Instead of returning an error when we call `probe.Attach()` on these probes, rely on the new `ActivatedProbes` list to return an error only when needed.

### Motivation

Fix support for kernels that do not support all the probes during a reload.
