### PR TITLE
[resolveLink] return the correct error if the link is not resolved

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cilium/ebpf v0.8.1
-	github.com/florianl/go-tc v0.3.0
+	github.com/florianl/go-tc v0.3.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/vishvananda/netlink v1.1.0

--- a/probe.go
+++ b/probe.go
@@ -1017,7 +1017,7 @@ func (p *Probe) attachTCCLS() error {
 	var err error
 	// Resolve Probe's interface
 	if _, err = p.resolveLink(); err != nil {
-		return ErrInterfaceNotSet
+		return err
 	}
 
 	// Recover the netlink socket of the interface from the manager
@@ -1230,7 +1230,7 @@ func (p *Probe) attachXDP() error {
 	var err error
 	// Resolve Probe's interface
 	if _, err = p.resolveLink(); err != nil {
-		return ErrInterfaceNotSet
+		return err
 	}
 
 	// Attach program
@@ -1246,7 +1246,7 @@ func (p *Probe) detachXDP() error {
 	var err error
 	// Resolve Probe's interface
 	if _, err = p.resolveLink(); err != nil {
-		return ErrInterfaceNotSet
+		return err
 	}
 
 	// Detach program


### PR DESCRIPTION
### What does this PR do?

This PR fixes the returned error when an interface couldn't be resolved.

### Motivation

Return the correct error when a program couldn't be loaded because an interface wasn't found.
