### PR TITLE
[link] Expose the interface on which a probe is attached

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -509,8 +509,8 @@ func (p *Probe) init() error {
 	return nil
 }
 
-// resolveLink - Resolves the Probe's network interface
-func (p *Probe) resolveLink() (netlink.Link, error) {
+// ResolveLink - Resolves the Probe's network interface
+func (p *Probe) ResolveLink() (netlink.Link, error) {
 	if p.link != nil {
 		return p.link, nil
 	}
@@ -1016,7 +1016,7 @@ func (p *Probe) buildTCFilter() (netlink.BpfFilter, error) {
 func (p *Probe) attachTCCLS() error {
 	var err error
 	// Resolve Probe's interface
-	if _, err = p.resolveLink(); err != nil {
+	if _, err = p.ResolveLink(); err != nil {
 		return err
 	}
 
@@ -1229,7 +1229,7 @@ func (p *Probe) cleanupTCFilters(ntl *NetlinkSocket) error {
 func (p *Probe) attachXDP() error {
 	var err error
 	// Resolve Probe's interface
-	if _, err = p.resolveLink(); err != nil {
+	if _, err = p.ResolveLink(); err != nil {
 		return err
 	}
 
@@ -1245,7 +1245,7 @@ func (p *Probe) attachXDP() error {
 func (p *Probe) detachXDP() error {
 	var err error
 	// Resolve Probe's interface
-	if _, err = p.resolveLink(); err != nil {
+	if _, err = p.ResolveLink(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR exposes the `ResolveLink` method of `Probe`. This is useful to retrieve the interface on which a probe is attached, without having to resolve it again from its namespace and ifindex.

### Motivation

This is required for a feature in the datadog-agent.
