### PR TITLE
[CWS] improve kprobe attachment by skipping PMU if it failed before

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -776,7 +776,7 @@ func (p *Probe) attachWithKprobeEvents() error {
 	return nil
 }
 
-var kprobePMUNotSupported uint32 = 0
+var kprobePMUNotSupported uint32
 
 // attachKprobe - Attaches the probe to its kprobe
 func (p *Probe) attachKprobe() error {

--- a/probe.go
+++ b/probe.go
@@ -790,13 +790,15 @@ func (p *Probe) attachKprobe() error {
 		return p.attachUprobe()
 	}
 
+	isKRetProbe := p.GetKprobeType() == RetProbeType
+
 	if kprobePMUNotSupported {
 		if err = p.attachWithKprobeEvents(); err != nil {
 			return err
 		}
-	} else if p.KProbeMaxActive > 0 && p.GetKprobeType() == RetProbeType { // currently the perf event open ABI doesn't allow to specify the max active parameter
+	} else if p.KProbeMaxActive > 0 && isKRetProbe { // currently the perf event open ABI doesn't allow to specify the max active parameter
 		if err = p.attachWithKprobeEvents(); err != nil {
-			if p.perfEventFD, err = perfEventOpenPMU(p.HookFuncName, 0, -1, "kprobe", true, 0); err != nil {
+			if p.perfEventFD, err = perfEventOpenPMU(p.HookFuncName, 0, -1, "kprobe", isKRetProbe, 0); err != nil {
 				if errors.Is(err, ErrNotSupported) {
 					kprobePMUNotSupported = true
 				}
@@ -804,7 +806,7 @@ func (p *Probe) attachKprobe() error {
 			}
 		}
 	} else {
-		if p.perfEventFD, err = perfEventOpenPMU(p.HookFuncName, 0, -1, "kprobe", false, 0); err != nil {
+		if p.perfEventFD, err = perfEventOpenPMU(p.HookFuncName, 0, -1, "kprobe", isKRetProbe, 0); err != nil {
 			if errors.Is(err, ErrNotSupported) {
 				kprobePMUNotSupported = true
 			}


### PR DESCRIPTION
### What does this PR do?

This PR:
- skips PMU attach if it failed before because it's not supported (this function is called more than 600 times in a simple rulesetloaded test, it's really in the hot path).
- fixes an edge case if `KProbeMaxActive` is set to 0.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
