### PR TITLE
[manager] Fix multiple races when programs are attached or detached at runtime

### DIFF
--- a/err.go
+++ b/err.go
@@ -12,6 +12,7 @@ var (
 	ErrMapNameInUse             = errors.New("the provided map name is already taken")
 	ErrIdentificationPairInUse  = errors.New("the provided identification pair already exists")
 	ErrProbeNotInitialized      = errors.New("the probe must be initialized first")
+	ErrProbeRunning             = errors.New("the probe is already running")
 	ErrSectionFormat            = errors.New("invalid section format")
 	ErrSymbolNotFound           = errors.New("symbol not found")
 	ErrKprobeIDNotExist         = errors.New("kprobe id file doesn't exist")

--- a/examples/object_pinning/main.go
+++ b/examples/object_pinning/main.go
@@ -15,7 +15,6 @@ var m = &manager.Manager{
 				EBPFSection:  "kprobe/mkdirat",
 				EBPFFuncName: "kprobe_mkdirat",
 			},
-			PinPath:         "/sys/fs/bpf/mkdirat",
 			SyscallFuncName: "mkdirat",
 		},
 		{
@@ -30,7 +29,6 @@ var m = &manager.Manager{
 				EBPFSection:  "kprobe/mkdir",
 				EBPFFuncName: "kprobe_mkdir",
 			},
-			PinPath:         "/sys/fs/bpf/mkdir",
 			SyscallFuncName: "mkdir",
 		},
 		{
@@ -77,7 +75,7 @@ func main() {
 	}
 
 	if kill {
-		logrus.Println("=> Stopping the program without cleanup, the pinned map and programs should show up in /sys/fs/bpf/")
+		logrus.Println("=> Stopping the program without cleanup, the pinned map should show up in /sys/fs/bpf/")
 		logrus.Println("=> Restart without --kill to load the pinned object from the bpf file system and properly remove them")
 		return
 	}

--- a/map.go
+++ b/map.go
@@ -91,7 +91,7 @@ func loadNewMap(spec ebpf.MapSpec, options MapOptions) (*Map, error) {
 
 	// Pin map if need be
 	if managerMap.PinPath != "" {
-		if err := managerMap.array.Pin(managerMap.PinPath); err != nil {
+		if err = managerMap.array.Pin(managerMap.PinPath); err != nil {
 			return nil, fmt.Errorf("couldn't pin map %s at %s: %w", managerMap.Name, managerMap.PinPath, err)
 		}
 	}
@@ -113,7 +113,9 @@ func (m *Map) Init(manager *Manager) error {
 			return fmt.Errorf("couldn't find map at maps/%s: %w", m.Name, ErrUnknownSection)
 		}
 		m.array = array
+	}
 
+	if m.array != nil {
 		// Pin map if needed
 		if m.PinPath != "" {
 			if err := m.array.Pin(m.PinPath); err != nil {
@@ -121,6 +123,7 @@ func (m *Map) Init(manager *Manager) error {
 			}
 		}
 	}
+
 	m.state = initialized
 	return nil
 }

--- a/probe.go
+++ b/probe.go
@@ -349,6 +349,18 @@ func (p *Probe) IsInitialized() bool {
 	return p.state >= initialized
 }
 
+// RenameProbeIdentificationPair - Renames the probe identification pair of a probe
+func (p *Probe) RenameProbeIdentificationPair(newID ProbeIdentificationPair) error {
+	p.stateLock.Lock()
+	defer p.stateLock.Unlock()
+	if p.state >= running {
+		return fmt.Errorf("couldn't rename ProbeIdentificationPair of %s with %s: %w", p.ProbeIdentificationPair, newID, ErrProbeRunning)
+	}
+	p.EBPFSection = newID.EBPFSection
+	p.UID = newID.UID
+	return nil
+}
+
 // Test - Triggers the probe with the provided test data. Returns the length of the output, the raw output or an error.
 func (p *Probe) Test(in []byte) (uint32, []byte, error) {
 	return p.program.Test(in)

--- a/selectors.go
+++ b/selectors.go
@@ -5,6 +5,57 @@ import (
 	"strings"
 )
 
+// ProbesSelector - A probe selector defines how a probe (or a group of probes) should be activated.
+//
+// For example, this can be used to specify that out of a group of optional probes, at least one should be activated.
+type ProbesSelector interface {
+	// GetProbesIdentificationPairList - Returns the list of probes that this selector activates
+	GetProbesIdentificationPairList() []ProbeIdentificationPair
+	// runValidator - Ensures that the probes that were successfully activated follow the selector goal.
+	// For example, see OneOf.
+	runValidator(manager *Manager) error
+	// EditProbeIdentificationPair - Changes all the selectors looking for the old ProbeIdentificationPair so that they
+	// mow select the new one
+	EditProbeIdentificationPair(old ProbeIdentificationPair, new ProbeIdentificationPair)
+}
+
+// ProbeSelector - This selector is used to unconditionally select a probe by its identification pair and validate
+// that it is activated
+type ProbeSelector struct {
+	ProbeIdentificationPair
+}
+
+// GetProbesIdentificationPairList - Returns the list of probes that this selector activates
+func (ps *ProbeSelector) GetProbesIdentificationPairList() []ProbeIdentificationPair {
+	return []ProbeIdentificationPair{ps.ProbeIdentificationPair}
+}
+
+// runValidator - Ensures that the probes that were successfully activated follow the selector goal.
+// For example, see OneOf.
+func (ps *ProbeSelector) runValidator(manager *Manager) error {
+	p, ok := manager.getProbe(ps.ProbeIdentificationPair)
+	if !ok {
+		return fmt.Errorf("probe not found: %s", ps.ProbeIdentificationPair)
+	}
+	if !p.IsRunning() && p.Enabled {
+		return fmt.Errorf("%s: %w", ps.ProbeIdentificationPair.String(), p.GetLastError())
+	}
+	if !p.Enabled {
+		return fmt.Errorf(
+			"%s: is disabled, add it to the activation list and check that it was not explicitly excluded by the manager options",
+			ps.ProbeIdentificationPair.String())
+	}
+	return nil
+}
+
+// EditProbeIdentificationPair - Changes all the selectors looking for the old ProbeIdentificationPair so that they
+// mow select the new one
+func (ps *ProbeSelector) EditProbeIdentificationPair(old ProbeIdentificationPair, new ProbeIdentificationPair) {
+	if ps.Matches(old) {
+		ps.ProbeIdentificationPair = new
+	}
+}
+
 // OneOf - This selector is used to ensure that at least of a list of probe selectors is valid. In other words, this
 // can be used to ensure that at least one of a list of optional probes is activated.
 type OneOf struct {
@@ -20,12 +71,12 @@ func (oo *OneOf) GetProbesIdentificationPairList() []ProbeIdentificationPair {
 	return l
 }
 
-// RunValidator - Ensures that the probes that were successfully activated follow the selector goal.
+// runValidator - Ensures that the probes that were successfully activated follow the selector goal.
 // For example, see OneOf.
-func (oo *OneOf) RunValidator(manager *Manager) error {
+func (oo *OneOf) runValidator(manager *Manager) error {
 	var errs []string
 	for _, selector := range oo.Selectors {
-		if err := selector.RunValidator(manager); err != nil {
+		if err := selector.runValidator(manager); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}
@@ -69,12 +120,12 @@ func (ao *AllOf) GetProbesIdentificationPairList() []ProbeIdentificationPair {
 	return l
 }
 
-// RunValidator - Ensures that the probes that were successfully activated follow the selector goal.
+// runValidator - Ensures that the probes that were successfully activated follow the selector goal.
 // For example, see OneOf.
-func (ao *AllOf) RunValidator(manager *Manager) error {
+func (ao *AllOf) runValidator(manager *Manager) error {
 	var errMsg []string
 	for _, selector := range ao.Selectors {
-		if err := selector.RunValidator(manager); err != nil {
+		if err := selector.runValidator(manager); err != nil {
 			errMsg = append(errMsg, err.Error())
 		}
 	}
@@ -118,9 +169,9 @@ func (be *BestEffort) GetProbesIdentificationPairList() []ProbeIdentificationPai
 	return l
 }
 
-// RunValidator - Ensures that the probes that were successfully activated follow the selector goal.
+// runValidator - Ensures that the probes that were successfully activated follow the selector goal.
 // For example, see OneOf.
-func (be *BestEffort) RunValidator(manager *Manager) error {
+func (be *BestEffort) runValidator(manager *Manager) error {
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes multiple races that occurs when the manager is modified at runtime by different goroutines. For example, if 2 goroutines try to attach and detach a hook point at the same time, the following race may happen:

```
WARNING: DATA RACE
       Read at 0x00c0004f64d8 by goroutine 71:
         github.com/DataDog/ebpf-manager.(*Manager).stop()
             /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.0.0-20220218133217-a77b0591856e/manager.go:698 +0x210
         github.com/DataDog/ebpf-manager.(*Manager).Stop()
             /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.0.0-20220218133217-a77b0591856e/manager.go:684 +0x12d
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Close()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:954 +0x77
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).Close()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:391 +0x208
         github.com/DataDog/datadog-agent/pkg/security/tests.(*testModule).cleanup()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:1013 +0x92
         github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:498 +0xc29
         github.com/DataDog/datadog-agent/pkg/security/tests.TestOpen()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/open_test.go:38 +0x1d2
         testing.tRunner()
             /root/.gimme/versions/go1.17.6.linux.amd64/src/testing/testing.go:1259 +0x22f
         testing.(*T).Run·dwrap·21()
             /root/.gimme/versions/go1.17.6.linux.amd64/src/testing/testing.go:1306 +0x47
       
       Previous write at 0x00c0004f64d8 by goroutine 31:
         github.com/DataDog/ebpf-manager.(*Manager).DetachHook()
             /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.0.0-20220218133217-a77b0591856e/manager.go:919 +0x7c4
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).flushInactiveProbes()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:1058 +0x3e4
         github.com/DataDog/datadog-agent/pkg/security/probe.(*NamespaceResolver).flushNamespaces()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/namespace_resolver.go:392 +0xf5
         github.com/DataDog/datadog-agent/pkg/security/probe.(*NamespaceResolver).Start·dwrap·23()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/namespace_resolver.go:379 +0x58
```

For safe measure, all exported functions were checked and various `m.stateLock.Lock()` / `defer m.stateLock.Unlock()` were added were similar races could happen.

### Motivation

A few data races where discovered by the Datadog Agent CI.
