### PR TITLE
[TC classifiers] Prevent attaching TC with an empty parent

### DIFF
--- a/err.go
+++ b/err.go
@@ -24,4 +24,5 @@ var (
 	ErrMapNotInitialized        = errors.New("the map must be initialized first")
 	ErrMapNotRunning            = errors.New("the map is not running")
 	ErrNotSupported             = errors.New("not supported")
+	ErrNoNetworkDirection       = errors.New("a valid network direction is required to attach a TC classifier")
 )


### PR DESCRIPTION
### What does this PR do?

This PR ensures that all TC classifiers are loaded on the `clsact` qdisc by hardcoding the parent handle.

### Motivation

After messing up a tiny little configuration of a manager in the Datadog Agent, we eventually started a TC classifier probe with `p.NetworkDirection = 0`. This lead to a drop in network connectivity on the host (on most interfaces). Deleting the `clsact` qdisc (on the impacted interfaces) didn't change anything, and only a restart of the agent made the interfaces recover.

A few hours of debugging later, here is what happened:
- by default, most interfaces default to a `fq_codel` for their root qdisc.
- when trying to load a TC classifier with a `0` as parent handle, [the kernel defaults](https://github.com/torvalds/linux/blob/ed4643521e6af8ab8ed1e467630a85884d2696cf/net/sched/cls_api.c#L1046-L1048) to selecting the `root` qdisc (although its handle should be `1`). This explains why deleting the `clsact` qdisc didn't change anything.
- although the `fq_codel` qdisc is a classless qdsic, it [allows external classifiers](https://github.com/torvalds/linux/blob/ed4643521e6af8ab8ed1e467630a85884d2696cf/net/sched/sch_fq_codel.c#L29) to be used to alter how packets are scheduled within the qdisc (but how the classifier is used by the qdisc is not documented 🎉  ).
- turns out, when the TC classifier returns TC_ACT_OK, [the lowest 2 bytes](https://github.com/torvalds/linux/blob/ed4643521e6af8ab8ed1e467630a85884d2696cf/net/sched/sch_fq_codel.c#L108) of the `classid` field of the `skb` is used to choose the `flow` bucket in which it will be appended.
- more precisely, the bucket index is `classid - 1`. If `classid` is not set (or set to 0), [then the packet is dropped](https://github.com/torvalds/linux/blob/ed4643521e6af8ab8ed1e467630a85884d2696cf/net/sched/sch_fq_codel.c#L194-L200). This explains why we lost all network connectivity on only a few interfaces => only the ones using the `fq_codel` qdisc.