### PR TITLE
[memory] Cleanup program spec

### DIFF
--- a/editor_test.go
+++ b/editor_test.go
@@ -25,11 +25,9 @@ func ExampleEditor_rewriteConstant() {
 	// This assembly is roughly equivalent to what clang
 	// would emit for the C above.
 	insns := asm.Instructions{
-		asm.LoadImm(asm.R0, 0, asm.DWord),
+		asm.LoadImm(asm.R0, 0, asm.DWord).WithReference("my_ret"),
 		asm.Return(),
 	}
-
-	insns[0].Reference = "my_ret"
 
 	editor := Edit(&insns)
 	if err := editor.RewriteConstant("my_ret", 42); err != nil {
@@ -82,15 +80,13 @@ func TestEditorIssue59(t *testing.T) {
 	max := uint64(math.MaxUint64)
 
 	insns := asm.Instructions{
-		asm.LoadImm(asm.R1, 0, asm.DWord),
+		asm.LoadImm(asm.R1, 0, asm.DWord).WithReference("my_ret"),
 		asm.RSh.Imm(asm.R1, 63),
 		asm.Mov.Imm(asm.R0, 1),
 		asm.JGT.Imm(asm.R1, 0, "exit"),
 		asm.Mov.Imm(asm.R0, 0),
 		asm.Return().Sym("exit"),
 	}
-
-	insns[0].Reference = "my_ret"
 
 	editor := Edit(&insns)
 	if err := editor.RewriteConstant("my_ret", max); err != nil {

--- a/examples/clone_vs_add_hook/main.go
+++ b/examples/clone_vs_add_hook/main.go
@@ -14,6 +14,7 @@ var m = &manager.Manager{
 				EBPFSection:  "kprobe/vfs_mkdir",
 				EBPFFuncName: "kprobe_vfs_mkdir",
 			},
+			KeepProgramSpec: true,
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
@@ -69,7 +70,10 @@ var editors = []manager.ConstantEditor{
 
 func main() {
 	// Prepare manager options
-	options := manager.Options{ConstantEditors: editors}
+	options := manager.Options{
+		ConstantEditors:          editors,
+		KeepUnmappedProgramSpecs: true,
+	}
 
 	// Initialize the manager
 	if err := m.InitWithOptions(recoverAssets(), options); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/cilium/ebpf v0.8.1
+	github.com/cilium/ebpf v0.8.2-0.20220404151855-0d439865ca15
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/vishvananda/netlink v1.1.1-0.20220316193741-b112db377d18

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1c8PVE1PubbNx3mjUr09OqWGCs=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
-github.com/cilium/ebpf v0.8.1 h1:bLSSEbBLqGPXxls55pGr5qWZaTqcmfDJHhou7t254ao=
-github.com/cilium/ebpf v0.8.1/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
+github.com/cilium/ebpf v0.8.2-0.20220404151855-0d439865ca15 h1:eZrQJDHgjOgeSOw2x8tgjO9B13n1BR9yqwlq1AIu2kk=
+github.com/cilium/ebpf v0.8.2-0.20220404151855-0d439865ca15/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/utils.go
+++ b/utils.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
 )
 
@@ -607,7 +608,7 @@ func getRetProbeBit(eventType string) (uint64, error) {
 	}
 }
 
-//GetEnv retrieves the environment variable key. If it does not exist it returns the default.
+// GetEnv retrieves the environment variable key. If it does not exist it returns the default.
 func GetEnv(key string, dfault string, combineWith ...string) string {
 	value := os.Getenv(key)
 	if value == "" {
@@ -642,4 +643,12 @@ func Getpid() int {
 		}
 	}
 	return os.Getpid()
+}
+
+// cleanupProgramSpec removes unused internal fields to free up some memory
+func cleanupProgramSpec(spec *ebpf.ProgramSpec) {
+	if spec != nil {
+		spec.Instructions = nil
+		spec.BTF = nil
+	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR cleans up unused fields of ProgramSpec instances when they're not needed anymore to free up memory.

### Motivation

Reduce the memory impact of the manager at runtime.
