### PR TITLE
[manager] delete internal TC probes on network namespace flush

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1866,7 +1866,7 @@ func (m *Manager) CleanupNetworkNamespace(nsID uint32) error {
 		// stop the probe
 		err = ConcatErrors(err, probe.Stop())
 
-		// append probe to delete
+		// append probe to delete (biggest indexes first)
 		toDelete = append([]int{i}, toDelete...)
 	}
 
@@ -1881,6 +1881,7 @@ func (m *Manager) CleanupNetworkNamespace(nsID uint32) error {
 
 	// delete probes
 	for _, i := range toDelete {
+		// we delete the biggest indexes first, so we should be good to go !
 		m.Probes = append(m.Probes[:i], m.Probes[i+1:]...)
 	}
 	return err


### PR DESCRIPTION
### What does this PR do?

This PR removes internal TC probes on network namespace flush. This ensures that we do not keep unused probes in the manager. It also ignores unnecessary probe "Init" errors so that they can be handled gracefully by the probe selector interface.

### Motivation

Help mitigate and prevent a race condition in the Datadog Agent during a reload.
