### PR TITLE
[TC] make the handle of a TC filter configurable

### DIFF
--- a/examples/programs/tc/main.go
+++ b/examples/programs/tc/main.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 
 	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -19,7 +20,7 @@ var m = &manager.Manager{
 				EBPFSection:  "classifier/egress",
 				EBPFFuncName: "egress",
 			},
-			IfName:           "enp0s3", // change this to the interface connected to the internet
+			IfName:           "lo", // change this to the interface connected to the internet
 			NetworkDirection: manager.Egress,
 		},
 		{
@@ -27,10 +28,11 @@ var m = &manager.Manager{
 				EBPFSection:  "classifier/ingress",
 				EBPFFuncName: "ingress",
 			},
-			IfName:           "enp0s3", // change this to the interface connected to the internet
+			IfName:           "lo", // change this to the interface connected to the internet
 			NetworkDirection: manager.Ingress,
 			TCFilterProtocol: unix.ETH_P_ARP,
 			TCFilterPrio:     1000,
+			TCFilterHandle:   netlink.MakeHandle(0, 2),
 		},
 	},
 }

--- a/probe.go
+++ b/probe.go
@@ -256,6 +256,9 @@ type Probe struct {
 	// in mind that if you are hooking on the host side of a virtuel ethernet pair, Ingress and Egress are inverted.
 	NetworkDirection TrafficType
 
+	// TCFilterHandle - (TC classifier) defines the handle to use when loading the classifier. Leave unset to let the kernel decide which handle to use.
+	TCFilterHandle uint32
+
 	// TCFilterPrio - (TC classifier) defines the priority of the classifier added to the clsact qdisc. Defaults to DefaultTCFilterPriority.
 	TCFilterPrio uint16
 
@@ -1054,6 +1057,7 @@ func (p *Probe) buildTCFilter() (netlink.BpfFilter, error) {
 			FilterAttrs: netlink.FilterAttrs{
 				LinkIndex: p.IfIndex,
 				Parent:    p.getTCFilterParentHandle(),
+				Handle:    p.TCFilterHandle,
 				Priority:  p.TCFilterPrio,
 				Protocol:  p.TCFilterProtocol,
 			},


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new attribute to the `Probe` structure: `TCFilterHandle`. This new attribute can be used to manually set the handle that the kernel should use for the bpf filter.

### Motivation

Allow the user to decide which filter to use.

### Describe how to test your changes

Run the TC example in `/examples/programs/tc` and make sure the loaded TC filter on ingress holds handle `0x2`.
