### PR TITLE
[TC] TC filter lazy deletion

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -1172,6 +1172,11 @@ func (p *Probe) IsTCFilterActive() bool {
 			return true
 		}
 	}
+
+	// This TC filter is no longer active, the interface has been deleted or the filter was replaced by a third party.
+	// Regardless of the reason, we do not hold the current Handle on this filter, remove it so we make sure we won't
+	// delete something that we do not own.
+	p.tcFilter.Handle = 0
 	return false
 }
 
@@ -1183,11 +1188,13 @@ func (p *Probe) detachTCCLS() error {
 		return err
 	}
 
-	// delete the current filter
-	if err = ntl.Sock.FilterDel(&p.tcFilter); err != nil {
-		// the device or the filter might already be gone, ignore the error if that's the case
-		if !errors.Is(err, syscall.ENODEV) && !errors.Is(err, syscall.ENOENT) {
-			return fmt.Errorf("couldn't remove TC classifier %v: %w", p.ProbeIdentificationPair, err)
+	if p.tcFilter.Handle > 0 {
+		// delete the current filter
+		if err = ntl.Sock.FilterDel(&p.tcFilter); err != nil {
+			// the device or the filter might already be gone, ignore the error if that's the case
+			if !errors.Is(err, syscall.ENODEV) && !errors.Is(err, syscall.ENOENT) {
+				return fmt.Errorf("couldn't remove TC classifier %v: %w", p.ProbeIdentificationPair, err)
+			}
 		}
 	}
 	ntl.TCFilterCount[p.IfIndex]--


### PR DESCRIPTION
### What does this PR do?

This PR mitigates an edge case where we might delete a TC filter that we do not own anymore if a third party stole the handle that the kernel gave us in the first place. There is by design a race when it comes to deleting a TC filter (nothing guarantees that we haven't been replaced), but this PR improves the situation ... a bit.
