### PR TITLE
[Probe] Introduce manager level attach method

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -173,6 +173,9 @@ type Options struct {
 	// See Probe.MaxActive for more.
 	DefaultKProbeMaxActive int
 
+	// DefaultKprobeAttachMethod - Manager-level default value for the Kprobe attach method. Defaults to AttachKprobeWithPerfEventOpen if unset.
+	DefaultKprobeAttachMethod KprobeAttachMethod
+
 	// ProbeRetry - Defines the number of times that a probe will retry to attach / detach on error.
 	DefaultProbeRetry uint
 

--- a/probe.go
+++ b/probe.go
@@ -126,7 +126,8 @@ func (pip ProbeIdentificationPair) GetUprobeType() string {
 type KprobeAttachMethod uint32
 
 const (
-	AttachKprobeWithPerfEventOpen KprobeAttachMethod = iota
+	AttachKprobeMethodNotSet KprobeAttachMethod = iota
+	AttachKprobeWithPerfEventOpen
 	AttachKprobeWithKprobeEvents
 )
 
@@ -544,6 +545,16 @@ func (p *Probe) init() error {
 			if available {
 				p.systemWideID = int(id)
 			}
+		}
+	}
+
+	// set default kprobe attach method
+	if p.KprobeAttachMethod == AttachKprobeMethodNotSet {
+		if p.manager != nil {
+			p.KprobeAttachMethod = p.manager.options.DefaultKprobeAttachMethod
+		}
+		if p.KprobeAttachMethod == AttachKprobeMethodNotSet {
+			p.KprobeAttachMethod = AttachKprobeWithPerfEventOpen
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR adds `DefaultKprobeAttachMethod` to the manager options. When a `Probe` doesn't have an attach method explicitly configured, it will default to the manager value or `AttachKprobeWithPerfEventOpen` if the probe doesn't have a manager.

### Motivation

This new default value can be used to globally set the attach method of all the probes of a manager, instead of having to manually set it for all the probes.

### Describe how to test your changes

The kprobe example can be used to check the manager parameter.