### PR TITLE
Add helpers to attach/detach tracing probes

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,6 +1,6 @@
 name: Build examples
 
-on: 
+on:
   push:
 
 jobs:
@@ -17,6 +17,7 @@ jobs:
           - object_pinning
           - program_router
           - programs/cgroup
+          - programs/fentry
           - programs/kprobe
           - programs/lsm
           - programs/perf_event

--- a/examples/programs/fentry/.gitignore
+++ b/examples/programs/fentry/.gitignore
@@ -1,0 +1,2 @@
+bin/
+ebpf/bin/

--- a/examples/programs/fentry/Makefile
+++ b/examples/programs/fentry/Makefile
@@ -1,0 +1,26 @@
+all: build-ebpf build run
+
+build-ebpf:
+	mkdir -p ebpf/bin
+	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+		-Wno-unused-value \
+		-Wno-pointer-sign \
+		-Wno-compare-distinct-pointer-types \
+		-Wunused \
+		-Wall \
+		-Werror \
+		-I/lib/modules/$$(uname -r)/build/include \
+		-I/lib/modules/$$(uname -r)/build/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
+		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-O2 -emit-llvm \
+		ebpf/main.c \
+		-c -g -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o
+
+build:
+	go build -o bin/main .
+
+run:
+	sudo bin/main

--- a/examples/programs/fentry/ebpf/main.c
+++ b/examples/programs/fentry/ebpf/main.c
@@ -1,0 +1,19 @@
+#include "../../../include/all.h"
+
+SEC("fentry/vfs_mkdir")
+int BPF_PROG(vfs_mkdir_enter, struct user_namespace *mnt_userns, struct inode *dir,
+             struct dentry *dentry, umode_t mode)
+{
+    bpf_printk("mkdir (vfs hook point) user_ns_ptr:%p\n", mnt_userns);
+    return 0;
+};
+
+SEC("fexit/do_mkdirat")
+int BPF_PROG(do_mkdirat_exit, int dfd, struct filename *fname, umode_t mode, int ret)
+{
+    bpf_printk("do_mkdirat return (syscall hook point) ret:%d\n", ret);
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";
+__u32 _version SEC("version") = 0xFFFFFFFE;

--- a/examples/programs/fentry/main.go
+++ b/examples/programs/fentry/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	manager "github.com/DataDog/ebpf-manager"
+)
+
+//go:embed ebpf/bin/probe.o
+var Probe []byte
+
+var m = &manager.Manager{
+	Probes: []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          "MyVFSMkdir",
+				EBPFSection:  "fentry/vfs_mkdir",
+				EBPFFuncName: "vfs_mkdir_enter",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID: "", // UID is needed only if there are multiple instances of your program (after using
+				// m.CloneProgram for example), or if multiple programs with the exact same section are attaching
+				// at the exact same hook point (using m.AddHook for example, or simply because another manager
+				// on the system is planning on hooking there).
+				EBPFSection:  "fexit/do_mkdirat",
+				EBPFFuncName: "do_mkdirat_exit",
+			},
+			SyscallFuncName: "mkdirat",
+		},
+	},
+}
+
+func main() {
+	options := manager.Options{
+		DefaultProbeRetry:      2,
+		DefaultProbeRetryDelay: time.Second,
+	}
+
+	// Initialize the manager
+	if err := m.InitWithOptions(bytes.NewReader(Probe), options); err != nil {
+		logrus.Fatal(err)
+	}
+
+	// Start the manager
+	if err := m.Start(); err != nil {
+		logrus.Fatal(err)
+	}
+
+	logrus.Println("successfully started")
+	logrus.Println("=> head over to /sys/kernel/debug/tracing/trace_pipe")
+	logrus.Println("=> checkout /sys/kernel/debug/tracing/kprobe_events, utimes_common might have become utimes_common.isra.0")
+	logrus.Println("=> Cmd+C to exit")
+
+	// Create a folder to trigger the probes
+	if err := trigger(); err != nil {
+		logrus.Error(err)
+	}
+
+	wait()
+
+	// Close the manager
+	if err := m.Stop(manager.CleanAll); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+// wait - Waits until an interrupt or kill signal is sent
+func wait() {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, os.Kill)
+	<-sig
+	fmt.Println()
+}

--- a/examples/programs/fentry/utils.go
+++ b/examples/programs/fentry/utils.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// trigger - Creates and then removes a tmp folder to trigger the probes
+func trigger() error {
+	logrus.Println("Generating events to trigger the probes ...")
+	// Creating a tmp directory to trigger the probes
+	tmpDir := "/tmp/test_folder"
+	logrus.Printf("creating %v", tmpDir)
+	err := os.MkdirAll(tmpDir, 0666)
+	if err != nil {
+		return err
+	}
+
+	// Removing a tmp directory to trigger the probes
+	logrus.Printf("removing %v", tmpDir)
+	return os.RemoveAll(tmpDir)
+}


### PR DESCRIPTION
### What does this PR do?

Adds helpers to attach/detach probes of type `ebpf.Tracing`.

### Motivation

fentry/fexit port of network tracer

### Additional Notes

### Describe how to test your changes
