### PR TITLE
Release kernel BTF on manager.Start()

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -648,6 +648,10 @@ func (m *Manager) Start() error {
 		return nil
 	}
 
+	// release kernel BTF. It should no longer be needed
+	// FIXME: this will break CloneProgram
+	m.options.VerifierOptions.Programs.KernelTypes = nil
+
 	// clean up tracefs
 	if err := m.cleanupTracefs(); err != nil {
 		m.stateLock.Unlock()


### PR DESCRIPTION
### What does this PR do?

Release kernel BTF (by setting pointer to `nil`) when `manager.Start()` is called.

### Motivation

Keeping the in-memory representation of the kernel BTF uses ~35MiB of heap.

### Additional Notes

This will break any programs loaded later, such as with `CloneProgram`. We intend to address this in a future PR.

### Describe how to test your changes


