### PR TITLE
Unexport several functions and types

### DIFF
--- a/editor.go
+++ b/editor.go
@@ -6,19 +6,19 @@ import (
 	"github.com/cilium/ebpf/asm"
 )
 
-// Editor modifies eBPF instructions.
-type Editor struct {
+// editor modifies eBPF instructions.
+type editor struct {
 	instructions     *asm.Instructions
 	ReferenceOffsets map[string][]int
 }
 
-// Edit creates a new Editor.
+// newEditor creates a new editor.
 //
 // The editor retains a reference to insns and modifies its
 // contents.
-func Edit(insns *asm.Instructions) *Editor {
+func newEditor(insns *asm.Instructions) *editor {
 	refs := insns.ReferenceOffsets()
-	return &Editor{insns, refs}
+	return &editor{insns, refs}
 }
 
 // RewriteConstant rewrites all loads of a symbol to a constant value.
@@ -43,9 +43,9 @@ func Edit(insns *asm.Instructions) *Editor {
 //   - Failing to rewrite a symbol will not result in an error,
 //     0 will be loaded instead (subject to change)
 //
-// Use IsUnreferencedSymbol if you want to rewrite potentially
+// Use isUnreferencedSymbol if you want to rewrite potentially
 // unused symbols.
-func (ed *Editor) RewriteConstant(symbol string, value uint64) error {
+func (ed *editor) RewriteConstant(symbol string, value uint64) error {
 	indices := ed.ReferenceOffsets[symbol]
 	if len(indices) == 0 {
 		return &unreferencedSymbolError{symbol}
@@ -71,9 +71,9 @@ func (use *unreferencedSymbolError) Error() string {
 	return fmt.Sprintf("unreferenced symbol %s", use.symbol)
 }
 
-// IsUnreferencedSymbol returns true if err was caused by
+// isUnreferencedSymbol returns true if err was caused by
 // an unreferenced symbol.
-func IsUnreferencedSymbol(err error) bool {
+func isUnreferencedSymbol(err error) bool {
 	_, ok := err.(*unreferencedSymbolError)
 	return ok
 }

--- a/editor_test.go
+++ b/editor_test.go
@@ -1,7 +1,6 @@
 package manager
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
@@ -21,24 +20,24 @@ import (
 //	    LOAD_CONSTANT("SYMBOL_NAME", my_constant);
 //
 //	    if (my_constant) ...
-func ExampleEditor_rewriteConstant() {
-	// This assembly is roughly equivalent to what clang
-	// would emit for the C above.
-	insns := asm.Instructions{
-		asm.LoadImm(asm.R0, 0, asm.DWord).WithReference("my_ret"),
-		asm.Return(),
-	}
-
-	editor := newEditor(&insns)
-	if err := editor.RewriteConstant("my_ret", 42); err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("%0.0s", insns)
-
-	// Output: 0: LdImmDW dst: r0 imm: 42 <my_ret>
-	// 2: Exit
-}
+//func ExampleEditor_rewriteConstant() {
+//	// This assembly is roughly equivalent to what clang
+//	// would emit for the C above.
+//	insns := asm.Instructions{
+//		asm.LoadImm(asm.R0, 0, asm.DWord).WithReference("my_ret"),
+//		asm.Return(),
+//	}
+//
+//	editor := newEditor(&insns)
+//	if err := editor.RewriteConstant("my_ret", 42); err != nil {
+//		panic(err)
+//	}
+//
+//	fmt.Printf("%0.0s", insns)
+//
+//	// Output: 0: LdImmDW dst: r0 imm: 42 <my_ret>
+//	// 2: Exit
+//}
 
 func TestEditorRewriteConstant(t *testing.T) {
 	spec, err := ebpf.LoadCollectionSpec("testdata/rewrite.elf")

--- a/editor_test.go
+++ b/editor_test.go
@@ -29,7 +29,7 @@ func ExampleEditor_rewriteConstant() {
 		asm.Return(),
 	}
 
-	editor := Edit(&insns)
+	editor := newEditor(&insns)
 	if err := editor.RewriteConstant("my_ret", 42); err != nil {
 		panic(err)
 	}
@@ -47,13 +47,13 @@ func TestEditorRewriteConstant(t *testing.T) {
 	}
 
 	progSpec := spec.Programs["socket"]
-	editor := Edit(&progSpec.Instructions)
+	editor := newEditor(&progSpec.Instructions)
 
 	if err := editor.RewriteConstant("constant", 0x01); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := editor.RewriteConstant("bogus", 0x01); !IsUnreferencedSymbol(err) {
+	if err := editor.RewriteConstant("bogus", 0x01); !isUnreferencedSymbol(err) {
 		t.Error("Rewriting unreferenced symbol doesn't return appropriate error")
 	}
 
@@ -88,7 +88,7 @@ func TestEditorIssue59(t *testing.T) {
 		asm.Return().WithSymbol("exit"),
 	}
 
-	editor := Edit(&insns)
+	editor := newEditor(&insns)
 	if err := editor.RewriteConstant("my_ret", max); err != nil {
 		t.Fatal(err)
 	}

--- a/map.go
+++ b/map.go
@@ -97,8 +97,8 @@ func loadNewMap(spec ebpf.MapSpec, options MapOptions) (*Map, error) {
 	return &managerMap, nil
 }
 
-// Init - Initialize a map
-func (m *Map) Init(manager *Manager) error {
+// init - Initialize a map
+func (m *Map) init(manager *Manager) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
 	if m.state >= initialized {
@@ -173,9 +173,9 @@ func (m *Map) close(cleanup MapCleanupType) error {
 		var err error
 		// Remove pin if needed
 		if m.PinPath != "" {
-			err = ConcatErrors(err, os.Remove(m.PinPath))
+			err = concatErrors(err, os.Remove(m.PinPath))
 		}
-		err = ConcatErrors(err, m.array.Close())
+		err = concatErrors(err, m.array.Close())
 		if err != nil {
 			return err
 		}

--- a/perf.go
+++ b/perf.go
@@ -62,8 +62,8 @@ func loadNewPerfMap(spec ebpf.MapSpec, options MapOptions, perfOptions PerfMapOp
 	return &perfMap, nil
 }
 
-// Init - Initialize a map
-func (m *PerfMap) Init(manager *Manager) error {
+// init - Initialize a map
+func (m *PerfMap) init(manager *Manager) error {
 	m.manager = manager
 
 	if m.DataHandler == nil && m.RecordHandler == nil {
@@ -79,7 +79,7 @@ func (m *PerfMap) Init(manager *Manager) error {
 	}
 
 	// Initialize the underlying map structure
-	if err := m.Map.Init(manager); err != nil {
+	if err := m.Map.init(manager); err != nil {
 		return err
 	}
 	return nil

--- a/probe.go
+++ b/probe.go
@@ -493,7 +493,7 @@ func (p *Probe) internalInit() error {
 		// if this is a kprobe or a kretprobe, look for the symbol now
 		if p.GetKprobeType() != UnknownProbeType {
 			var err error
-			p.HookFuncName, err = findFilterFunction(p.MatchFuncName)
+			p.HookFuncName, err = FindFilterFunction(p.MatchFuncName)
 			if err != nil {
 				p.lastError = err
 				return err

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -45,8 +45,8 @@ func loadNewRingBuffer(spec ebpf.MapSpec, options MapOptions, ringBufferOptions 
 	return &ringBuffer, nil
 }
 
-// Init - Initialize a ring buffer
-func (rb *RingBuffer) Init(manager *Manager) error {
+// init - Initialize a ring buffer
+func (rb *RingBuffer) init(manager *Manager) error {
 	rb.manager = manager
 
 	if rb.DataHandler == nil {
@@ -59,7 +59,7 @@ func (rb *RingBuffer) Init(manager *Manager) error {
 	}
 
 	// Initialize the underlying map structure
-	if err := rb.Map.Init(manager); err != nil {
+	if err := rb.Map.init(manager); err != nil {
 		return err
 	}
 	return nil

--- a/utils.go
+++ b/utils.go
@@ -27,18 +27,18 @@ const (
 	paused
 	running
 
-	// MaxEventNameLen - maximum length for a kprobe (or uprobe) event name
+	// maxEventNameLen - maximum length for a kprobe (or uprobe) event name
 	// MAX_EVENT_NAME_LEN (linux/kernel/trace/trace.h)
-	MaxEventNameLen    = 64
-	MinFunctionNameLen = 10
+	maxEventNameLen    = 64
+	minFunctionNameLen = 10
 
-	// MaxBPFClassifierNameLen - maximum length for a TC
+	// maxBPFClassifierNameLen - maximum length for a TC
 	// CLS_BPF_NAME_LEN (linux/net/sched/cls_bpf.c)
-	MaxBPFClassifierNameLen = 256
+	maxBPFClassifierNameLen = 256
 )
 
-// ConcatErrors - Concatenate 2 errors into one error.
-func ConcatErrors(err1, err2 error) error {
+// concatErrors - Concatenate 2 errors into one error.
+func concatErrors(err1, err2 error) error {
 	if err1 == nil {
 		return err2
 	}
@@ -51,7 +51,7 @@ func ConcatErrors(err1, err2 error) error {
 // availableFilterFunctions - cache of the list of available kernel functions.
 var availableFilterFunctions []string
 
-func FindFilterFunction(funcName string) (string, error) {
+func findFilterFunction(funcName string) (string, error) {
 	// Prepare matching pattern
 	searchedName, err := regexp.Compile(funcName)
 	if err != nil {
@@ -126,7 +126,7 @@ func GetSyscallFnNameWithSymFile(name string, symFile string) (string, error) {
 const defaultSymFile = "/proc/kallsyms"
 
 // Returns the qualified syscall named by going through '/proc/kallsyms' on the
-// system on which its executed. It allows BPF programs that may have been compiled
+// system on which its executed. It allows bpf programs that may have been compiled
 // for older syscall functions to run on newer kernels
 func getSyscallName(name string, symFile string) (string, error) {
 	// Get kernel symbols
@@ -183,33 +183,33 @@ func getSyscallFnNameWithKallsyms(name string, kallsymsContent string) (string, 
 
 var safeEventRegexp = regexp.MustCompile("[^a-zA-Z0-9]")
 
-func GenerateEventName(probeType, funcName, UID string, attachPID int) (string, error) {
+func generateEventName(probeType, funcName, UID string, attachPID int) (string, error) {
 	// truncate the function name and UID name to reduce the length of the event
 	attachPIDstr := strconv.Itoa(attachPID)
-	maxFuncNameLen := MaxEventNameLen - 3 /* _ */ - len(probeType) - len(UID) - len(attachPIDstr)
-	if maxFuncNameLen < MinFunctionNameLen { /* let's guarantee that we have a function name minimum of 10 chars (MinFunctionNameLen) or trow an error */
+	maxFuncNameLen := maxEventNameLen - 3 /* _ */ - len(probeType) - len(UID) - len(attachPIDstr)
+	if maxFuncNameLen < minFunctionNameLen { /* let's guarantee that we have a function name minimum of 10 chars (minFunctionNameLen) or trow an error */
 		dbgFullEventString := safeEventRegexp.ReplaceAllString(fmt.Sprintf("%s_%s_%s_%s", probeType, funcName, UID, attachPIDstr), "_")
-		return "", fmt.Errorf("event name is too long (kernel limit is %d (MAX_EVENT_NAME_LEN)): MinFunctionNameLen %d, len 3, probeType %d, funcName %d, UID %d, attachPIDstr %d ; full event string : '%s'", MaxEventNameLen, MinFunctionNameLen, len(probeType), len(funcName), len(UID), len(attachPIDstr), dbgFullEventString)
+		return "", fmt.Errorf("event name is too long (kernel limit is %d (MAX_EVENT_NAME_LEN)): minFunctionNameLen %d, len 3, probeType %d, funcName %d, UID %d, attachPIDstr %d ; full event string : '%s'", maxEventNameLen, minFunctionNameLen, len(probeType), len(funcName), len(UID), len(attachPIDstr), dbgFullEventString)
 	}
 	eventName := safeEventRegexp.ReplaceAllString(fmt.Sprintf("%s_%.*s_%s_%s", probeType, maxFuncNameLen, funcName, UID, attachPIDstr), "_")
 
-	if len(eventName) > MaxEventNameLen {
-		return "", fmt.Errorf("event name too long (kernel limit MAX_EVENT_NAME_LEN is %d): '%s'", MaxEventNameLen, eventName)
+	if len(eventName) > maxEventNameLen {
+		return "", fmt.Errorf("event name too long (kernel limit MAX_EVENT_NAME_LEN is %d): '%s'", maxEventNameLen, eventName)
 	}
 	return eventName, nil
 }
 
-func GenerateTCFilterName(UID, sectionName string, attachPID int) (string, error) {
+func generateTCFilterName(UID, sectionName string, attachPID int) (string, error) {
 	attachPIDstr := strconv.Itoa(attachPID)
-	maxSectionNameLen := MaxBPFClassifierNameLen - 3 /* _ */ - len(UID) - len(attachPIDstr)
+	maxSectionNameLen := maxBPFClassifierNameLen - 3 /* _ */ - len(UID) - len(attachPIDstr)
 	if maxSectionNameLen < 0 {
 		dbgFullFilterString := safeEventRegexp.ReplaceAllString(fmt.Sprintf("%s_%s_%s", sectionName, UID, attachPIDstr), "_")
-		return "", fmt.Errorf("filter name is too long (kernel limit is %d (CLS_BPF_NAME_LEN)): sectionName %d, UID %d, attachPIDstr %d ; full event string : '%s'", MaxEventNameLen, len(sectionName), len(UID), len(attachPIDstr), dbgFullFilterString)
+		return "", fmt.Errorf("filter name is too long (kernel limit is %d (CLS_BPF_NAME_LEN)): sectionName %d, UID %d, attachPIDstr %d ; full event string : '%s'", maxEventNameLen, len(sectionName), len(UID), len(attachPIDstr), dbgFullFilterString)
 	}
 	filterName := safeEventRegexp.ReplaceAllString(fmt.Sprintf("%.*s_%s_%s", maxSectionNameLen, sectionName, UID, attachPIDstr), "_")
 
-	if len(filterName) > MaxBPFClassifierNameLen {
-		return "", fmt.Errorf("filter name too long (kernel limit CLS_BPF_NAME_LEN is %d): '%s'", MaxBPFClassifierNameLen, filterName)
+	if len(filterName) > maxBPFClassifierNameLen {
+		return "", fmt.Errorf("filter name too long (kernel limit CLS_BPF_NAME_LEN is %d): '%s'", maxBPFClassifierNameLen, filterName)
 	}
 	return filterName, nil
 }
@@ -220,8 +220,8 @@ func getKernelGeneratedEventName(probeType, funcName string) string {
 	return fmt.Sprintf("%s_%s_0", probeType, funcName)
 }
 
-// ReadKprobeEvents - Returns the content of kprobe_events
-func ReadKprobeEvents() (string, error) {
+// readKprobeEvents - Returns the content of kprobe_events
+func readKprobeEvents() (string, error) {
 	kprobeEvents, err := os.ReadFile("/sys/kernel/debug/tracing/kprobe_events")
 	if err != nil {
 		return "", err
@@ -233,7 +233,7 @@ func ReadKprobeEvents() (string, error) {
 // to remove the krpobe.
 func registerKprobeEvent(probeType, funcName, UID, maxActiveStr string, kprobeAttachPID int) (int, error) {
 	// Generate event name
-	eventName, err := GenerateEventName(probeType, funcName, UID, kprobeAttachPID)
+	eventName, err := generateEventName(probeType, funcName, UID, kprobeAttachPID)
 	if err != nil {
 		return -1, err
 	}
@@ -270,7 +270,7 @@ func registerKprobeEvent(probeType, funcName, UID, maxActiveStr string, kprobeAt
 // unregisterKprobeEvent - Removes a kprobe from kprobe_events
 func unregisterKprobeEvent(probeType, funcName, UID string, kprobeAttachPID int) error {
 	// Generate event name
-	eventName, err := GenerateEventName(probeType, funcName, UID, kprobeAttachPID)
+	eventName, err := generateEventName(probeType, funcName, UID, kprobeAttachPID)
 	if err != nil {
 		return err
 	}
@@ -300,8 +300,8 @@ func unregisterKprobeEventWithEventName(eventName string) error {
 	return nil
 }
 
-// ReadUprobeEvents - Returns the content of uprobe_events
-func ReadUprobeEvents() (string, error) {
+// readUprobeEvents - Returns the content of uprobe_events
+func readUprobeEvents() (string, error) {
 	uprobeEvents, err := os.ReadFile("/sys/kernel/debug/tracing/uprobe_events")
 	if err != nil {
 		return "", err
@@ -313,7 +313,7 @@ func ReadUprobeEvents() (string, error) {
 // to remove the krpobe.
 func registerUprobeEvent(probeType string, funcName, path, UID string, uprobeAttachPID int, offset uint64) (int, error) {
 	// Generate event name
-	eventName, err := GenerateEventName(probeType, funcName, UID, uprobeAttachPID)
+	eventName, err := generateEventName(probeType, funcName, UID, uprobeAttachPID)
 	if err != nil {
 		return -1, err
 	}
@@ -352,7 +352,7 @@ func registerUprobeEvent(probeType string, funcName, path, UID string, uprobeAtt
 // unregisterUprobeEvent - Removes a uprobe from uprobe_events
 func unregisterUprobeEvent(probeType string, funcName string, UID string, uprobeAttachPID int) error {
 	// Generate event name
-	eventName, err := GenerateEventName(probeType, funcName, UID, uprobeAttachPID)
+	eventName, err := generateEventName(probeType, funcName, UID, uprobeAttachPID)
 	if err != nil {
 		return err
 	}
@@ -374,8 +374,8 @@ func unregisterUprobeEventWithEventName(eventName string) error {
 	return nil
 }
 
-// OpenAndListSymbols - Opens an elf file and extracts all its symbols
-func OpenAndListSymbols(path string) (*elf.File, []elf.Symbol, error) {
+// openAndListSymbols - Opens an elf file and extracts all its symbols
+func openAndListSymbols(path string) (*elf.File, []elf.Symbol, error) {
 	// open elf file
 	f, err := elf.Open(path)
 	if err != nil {
@@ -404,8 +404,8 @@ func OpenAndListSymbols(path string) (*elf.File, []elf.Symbol, error) {
 	return f, syms, nil
 }
 
-// SanitizeUprobeAddresses - sanitizes the addresses of the provided symbols
-func SanitizeUprobeAddresses(f *elf.File, syms []elf.Symbol) {
+// sanitizeUprobeAddresses - sanitizes the addresses of the provided symbols
+func sanitizeUprobeAddresses(f *elf.File, syms []elf.Symbol) {
 	// If the binary is a non-PIE executable, addr must be a virtual address, otherwise it must be an offset relative to
 	// the file load address. For executable (ET_EXEC) binaries and shared objects (ET_DYN), translate the virtual
 	// address to physical address in the binary file.
@@ -422,9 +422,9 @@ func SanitizeUprobeAddresses(f *elf.File, syms []elf.Symbol) {
 	}
 }
 
-// FindSymbolOffsets - Parses the provided file and returns the offsets of the symbols that match the provided pattern
-func FindSymbolOffsets(path string, pattern *regexp.Regexp) ([]elf.Symbol, error) {
-	f, syms, err := OpenAndListSymbols(path)
+// findSymbolOffsets - Parses the provided file and returns the offsets of the symbols that match the provided pattern
+func findSymbolOffsets(path string, pattern *regexp.Regexp) ([]elf.Symbol, error) {
+	f, syms, err := openAndListSymbols(path)
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +440,7 @@ func FindSymbolOffsets(path string, pattern *regexp.Regexp) ([]elf.Symbol, error
 		return nil, ErrSymbolNotFound
 	}
 
-	SanitizeUprobeAddresses(f, matches)
+	sanitizeUprobeAddresses(f, matches)
 	return matches, nil
 }
 
@@ -458,38 +458,38 @@ func GetTracepointID(category, name string) (int, error) {
 	return tracepointID, nil
 }
 
-// ErrClosedFd - Use of closed file descriptor error
-var ErrClosedFd = errors.New("use of closed file descriptor")
+// errClosedFd - Use of closed file descriptor error
+var errClosedFd = errors.New("use of closed file descriptor")
 
-// FD - File descriptor
-type FD struct {
+// fd - File descriptor
+type fd struct {
 	raw int64
 }
 
-// NewFD - returns a new file descriptor
-func NewFD(value uint32) *FD {
-	fd := &FD{int64(value)}
-	runtime.SetFinalizer(fd, (*FD).Close)
+// newFD - returns a new file descriptor
+func newFD(value uint32) *fd {
+	fd := &fd{int64(value)}
+	runtime.SetFinalizer(fd, (*fd).Close)
 	return fd
 }
 
-func (fd *FD) String() string {
+func (fd *fd) String() string {
 	return strconv.FormatInt(fd.raw, 10)
 }
 
-func (fd *FD) Value() (uint32, error) {
+func (fd *fd) Value() (uint32, error) {
 	if fd.raw < 0 {
-		return 0, ErrClosedFd
+		return 0, errClosedFd
 	}
 
 	return uint32(fd.raw), nil
 }
 
-func (fd *FD) Forget() {
+func (fd *fd) Forget() {
 	runtime.SetFinalizer(fd, nil)
 }
 
-func (fd *FD) Close() error {
+func (fd *fd) Close() error {
 	if fd.raw < 0 {
 		return nil
 	}
@@ -607,8 +607,8 @@ func getRetProbeBit(eventType string) (uint64, error) {
 	}
 }
 
-// GetEnv retrieves the environment variable key. If it does not exist it returns the default.
-func GetEnv(key string, dfault string, combineWith ...string) string {
+// getEnv retrieves the environment variable key. If it does not exist it returns the default.
+func getEnv(key string, dfault string, combineWith ...string) string {
 	value := os.Getenv(key)
 	if value == "" {
 		value = dfault
@@ -627,15 +627,15 @@ func GetEnv(key string, dfault string, combineWith ...string) string {
 	}
 }
 
-// HostProc returns joins the provided path with the host /proc directory
-func HostProc(combineWith ...string) string {
-	return GetEnv("HOST_PROC", "/proc", combineWith...)
+// hostProc returns joins the provided path with the host /proc directory
+func hostProc(combineWith ...string) string {
+	return getEnv("HOST_PROC", "/proc", combineWith...)
 }
 
 // Getpid returns the current process ID in the host namespace if $HOST_PROC is defined, the pid in the current namespace
 // otherwise
 func Getpid() int {
-	p, err := os.Readlink(HostProc("/self"))
+	p, err := os.Readlink(hostProc("/self"))
 	if err == nil {
 		if pid, err := strconv.ParseInt(p, 10, 32); err == nil {
 			return int(pid)

--- a/utils.go
+++ b/utils.go
@@ -51,7 +51,7 @@ func concatErrors(err1, err2 error) error {
 // availableFilterFunctions - cache of the list of available kernel functions.
 var availableFilterFunctions []string
 
-func findFilterFunction(funcName string) (string, error) {
+func FindFilterFunction(funcName string) (string, error) {
 	// Prepare matching pattern
 	searchedName, err := regexp.Compile(funcName)
 	if err != nil {
@@ -374,8 +374,8 @@ func unregisterUprobeEventWithEventName(eventName string) error {
 	return nil
 }
 
-// openAndListSymbols - Opens an elf file and extracts all its symbols
-func openAndListSymbols(path string) (*elf.File, []elf.Symbol, error) {
+// OpenAndListSymbols - Opens an elf file and extracts all its symbols
+func OpenAndListSymbols(path string) (*elf.File, []elf.Symbol, error) {
 	// open elf file
 	f, err := elf.Open(path)
 	if err != nil {
@@ -404,8 +404,8 @@ func openAndListSymbols(path string) (*elf.File, []elf.Symbol, error) {
 	return f, syms, nil
 }
 
-// sanitizeUprobeAddresses - sanitizes the addresses of the provided symbols
-func sanitizeUprobeAddresses(f *elf.File, syms []elf.Symbol) {
+// SanitizeUprobeAddresses - sanitizes the addresses of the provided symbols
+func SanitizeUprobeAddresses(f *elf.File, syms []elf.Symbol) {
 	// If the binary is a non-PIE executable, addr must be a virtual address, otherwise it must be an offset relative to
 	// the file load address. For executable (ET_EXEC) binaries and shared objects (ET_DYN), translate the virtual
 	// address to physical address in the binary file.
@@ -424,7 +424,7 @@ func sanitizeUprobeAddresses(f *elf.File, syms []elf.Symbol) {
 
 // findSymbolOffsets - Parses the provided file and returns the offsets of the symbols that match the provided pattern
 func findSymbolOffsets(path string, pattern *regexp.Regexp) ([]elf.Symbol, error) {
-	f, syms, err := openAndListSymbols(path)
+	f, syms, err := OpenAndListSymbols(path)
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +440,7 @@ func findSymbolOffsets(path string, pattern *regexp.Regexp) ([]elf.Symbol, error
 		return nil, ErrSymbolNotFound
 	}
 
-	sanitizeUprobeAddresses(f, matches)
+	SanitizeUprobeAddresses(f, matches)
 	return matches, nil
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -10,24 +10,24 @@ func TestGenerateEventName(t *testing.T) {
 	UID := "UID"
 	kprobeAttachPID := 1234
 
-	eventName, err := GenerateEventName(probeType, funcName, UID, kprobeAttachPID)
+	eventName, err := generateEventName(probeType, funcName, UID, kprobeAttachPID)
 	if err != nil {
 		t.Error(err)
 	}
-	if len(eventName) > MaxEventNameLen {
-		t.Errorf("Event name too long, kernel limit is %d : MaxEventNameLen", MaxEventNameLen)
+	if len(eventName) > maxEventNameLen {
+		t.Errorf("Event name too long, kernel limit is %d : maxEventNameLen", maxEventNameLen)
 	}
 
 	// should be truncated
 	funcName = "01234567890123456790123456789012345678901234567890123456789"
-	eventName, err = GenerateEventName(probeType, funcName, UID, kprobeAttachPID)
-	if (err != nil) || (len(eventName) != MaxEventNameLen) || (eventName != "p_01234567890123456790123456789012345678901234567890123_UID_1234") {
+	eventName, err = generateEventName(probeType, funcName, UID, kprobeAttachPID)
+	if (err != nil) || (len(eventName) != maxEventNameLen) || (eventName != "p_01234567890123456790123456789012345678901234567890123_UID_1234") {
 		t.Errorf("Should not failed and truncate the function name (len %d)", len(eventName))
 	}
 
 	UID = "12345678901234567890123456789012345678901234567890"
-	_, err = GenerateEventName(probeType, funcName, UID, kprobeAttachPID)
+	_, err = generateEventName(probeType, funcName, UID, kprobeAttachPID)
 	if err == nil {
-		t.Errorf("Test should failed as event name length is too big for the kernel and free space for function Name is < %d", MinFunctionNameLen)
+		t.Errorf("Test should failed as event name length is too big for the kernel and free space for function Name is < %d", minFunctionNameLen)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Un-exports several functions and types.

### Motivation

I think most of these were not intended to be used by consumers of the library. Some are currently unused, and can be exported again under a more intentional API.

### Additional Notes

This may not be exhaustive, but is a good start.

### Describe how to test your changes

