### PR TITLE
[Bug] Fix SetFinalizer stack trace and bump to go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/ebpf-manager
 
-go 1.17
+go 1.18
 
 require (
 	github.com/DataDog/gopsutil v1.2.1

--- a/utils.go
+++ b/utils.go
@@ -468,9 +468,11 @@ type fd struct {
 
 // newFD - returns a new file descriptor
 func newFD(value uint32) *fd {
-	fd := &fd{int64(value)}
-	runtime.SetFinalizer(fd, (*fd).Close)
-	return fd
+	f := &fd{int64(value)}
+	runtime.SetFinalizer(f, func(f *fd) {
+		_ = f.Close()
+	})
+	return f
 }
 
 func (fd *fd) String() string {
@@ -485,10 +487,6 @@ func (fd *fd) Value() (uint32, error) {
 	return uint32(fd.raw), nil
 }
 
-func (fd *fd) Forget() {
-	runtime.SetFinalizer(fd, nil)
-}
-
 func (fd *fd) Close() error {
 	if fd.raw < 0 {
 		return nil
@@ -497,7 +495,6 @@ func (fd *fd) Close() error {
 	value := int(fd.raw)
 	fd.raw = -1
 
-	fd.Forget()
 	return unix.Close(value)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -495,6 +495,7 @@ func (fd *fd) Close() error {
 	value := int(fd.raw)
 	fd.raw = -1
 
+	runtime.SetFinalizer(fd, nil)
 	return unix.Close(value)
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR:
- Bump to go 1.18 since we bumped the Datadog Agent to go 1.18
- Fixes the stack trace below which started appearing on master since we stopped exporting some structures (don't ask why I have no idea). Regardless of why the stack trace started appearing, we use to set an invalid finalizer.

### Motivation

On my setup, main is currently broken. See the stack trace below:
```
fatal error: runtime.SetFinalizer: cannot pass *manager.fd to finalizer func() error

goroutine 1 [running]:
runtime.throw({0xc0001a4230?, 0x770668?})
	/home/will/.gimme/versions/go1.18.linux.amd64/src/runtime/panic.go:992 +0x71 fp=0xc0001e75b8 sp=0xc0001e7588 pc=0x434df1
runtime.SetFinalizer({0x71a140, 0xc00002a2d0}, {0x6f2b60, 0xc000020100})
	/home/will/.gimme/versions/go1.18.linux.amd64/src/runtime/mfinal.go:399 +0x48e fp=0xc0001e7690 sp=0xc0001e75b8 pc=0x41a0ae
github.com/DataDog/ebpf-manager.newFD(...)
	/home/will/go/src/github.com/DataDog/ebpf-manager/utils.go:472
github.com/DataDog/ebpf-manager.perfEventOpenPMU({0xc0001aac07, 0x9}, 0x0, 0xffffffffffffffff, {0x762f88, 0x6}, 0x0, 0x0)
	/home/will/go/src/github.com/DataDog/ebpf-manager/syscalls.go:82 +0x39f fp=0xc0001e77b0 sp=0xc0001e7690 pc=0x6c4c1f
github.com/DataDog/ebpf-manager.(*Probe).attachKprobe(0x9a40a0)
	/home/will/go/src/github.com/DataDog/ebpf-manager/probe.go:879 +0x468 fp=0xc0001e78c8 sp=0xc0001e77b0 pc=0x6c00e8
github.com/DataDog/ebpf-manager.(*Probe).attach(0x9a40a0)
	/home/will/go/src/github.com/DataDog/ebpf-manager/probe.go:642 +0x1da fp=0xc0001e7978 sp=0xc0001e78c8 pc=0x6be53a
github.com/DataDog/ebpf-manager.(*Probe).Attach.func1()
	/home/will/go/src/github.com/DataDog/ebpf-manager/probe.go:606 +0x25 fp=0xc0001e79b8 sp=0xc0001e7978 pc=0x6be265
github.com/avast/retry-go/v4.Do(0xc0001e7af8, {0xc0001e7b08, 0x3, 0xc0001e7b20?})
	/home/will/go/pkg/mod/github.com/avast/retry-go/v4@v4.1.0/retry.go:122 +0x274 fp=0xc0001e7aa8 sp=0xc0001e79b8 pc=0x6ae9f4
github.com/DataDog/ebpf-manager.(*Probe).Attach(0x9a2f20?)
	/home/will/go/src/github.com/DataDog/ebpf-manager/probe.go:604 +0xce fp=0xc0001e7b30 sp=0xc0001e7aa8 pc=0x6be20e
github.com/DataDog/ebpf-manager.(*Manager).Start(0x9a3a00)
	/home/will/go/src/github.com/DataDog/ebpf-manager/manager.go:685 +0x2f3 fp=0xc0001e7c20 sp=0xc0001e7b30 pc=0x6b2d33
main.main()
	/home/will/go/src/github.com/DataDog/ebpf-manager/examples/clone_vs_add_hook/main.go:90 +0x1b1 fp=0xc0001e7f80 sp=0xc0001e7c20 pc=0x6cbad1
runtime.main()
	/home/will/.gimme/versions/go1.18.linux.amd64/src/runtime/proc.go:250 +0x212 fp=0xc0001e7fe0 sp=0xc0001e7f80 pc=0x4375d2
runtime.goexit()
	/home/will/.gimme/versions/go1.18.linux.amd64/src/runtime/asm_amd64.s:1571 +0x1 fp=0xc0001e7fe8 sp=0xc0001e7fe0 pc=0x463961

goroutine 21 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0xc0001c4650, 0x0)
	/home/will/.gimme/versions/go1.18.linux.amd64/src/runtime/sema.go:513 +0x13d
sync.(*Cond).Wait(0x406bdd?)
	/home/will/.gimme/versions/go1.18.linux.amd64/src/sync/cond.go:56 +0x8c
github.com/cihub/seelog.(*asyncLoopLogger).processItem(0xc000224000)
	/home/will/go/pkg/mod/github.com/cihub/seelog@v0.0.0-20170130134532-f561c5e57575/behavior_asynclooplogger.go:50 +0xa5
github.com/cihub/seelog.(*asyncLoopLogger).processQueue(0xc000224000)
	/home/will/go/pkg/mod/github.com/cihub/seelog@v0.0.0-20170130134532-f561c5e57575/behavior_asynclooplogger.go:63 +0x35
created by github.com/cihub/seelog.NewAsyncLoopLogger
	/home/will/go/pkg/mod/github.com/cihub/seelog@v0.0.0-20170130134532-f561c5e57575/behavior_asynclooplogger.go:40 +0xca

goroutine 22 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0xc0001c47d0, 0x0)
	/home/will/.gimme/versions/go1.18.linux.amd64/src/runtime/sema.go:513 +0x13d
sync.(*Cond).Wait(0x0?)
	/home/will/.gimme/versions/go1.18.linux.amd64/src/sync/cond.go:56 +0x8c
github.com/cihub/seelog.(*asyncLoopLogger).processItem(0xc000224120)
	/home/will/go/pkg/mod/github.com/cihub/seelog@v0.0.0-20170130134532-f561c5e57575/behavior_asynclooplogger.go:50 +0xa5
github.com/cihub/seelog.(*asyncLoopLogger).processQueue(0xc000224120)
	/home/will/go/pkg/mod/github.com/cihub/seelog@v0.0.0-20170130134532-f561c5e57575/behavior_asynclooplogger.go:63 +0x35
created by github.com/cihub/seelog.NewAsyncLoopLogger
	/home/will/go/pkg/mod/github.com/cihub/seelog@v0.0.0-20170130134532-f561c5e57575/behavior_asynclooplogger.go:40 +0xca

goroutine 9 [syscall]:
syscall.Syscall6(0xe8, 0xa, 0xc0000f2000, 0x10, 0xffffffffffffffff, 0x0, 0x0)
	/home/will/.gimme/versions/go1.18.linux.amd64/src/syscall/asm_linux_amd64.s:43 +0x5
golang.org/x/sys/unix.EpollWait(0x0?, {0xc0000f2000?, 0x0?, 0x8d?}, 0xc00012d640?)
	/home/will/go/pkg/mod/golang.org/x/sys@v0.0.0-20220928140112-f11e5e49a4ec/unix/zsyscall_linux_amd64.go:56 +0x58
github.com/cilium/ebpf/internal/unix.EpollWait(...)
	/home/will/go/pkg/mod/github.com/cilium/ebpf@v0.9.3/internal/unix/types_linux.go:114
github.com/cilium/ebpf/internal/epoll.(*Poller).Wait(0xc0001c23c0, {0xc0000f2000?, 0x10, 0x10}, {0xa?, 0xc00012d738?, 0x0?})
	/home/will/go/pkg/mod/github.com/cilium/ebpf@v0.9.3/internal/epoll/poller.go:145 +0x2b4
github.com/cilium/ebpf/perf.(*Reader).ReadInto(0xc0001be000, 0x0?)
	/home/will/go/pkg/mod/github.com/cilium/ebpf@v0.9.3/perf/reader.go:324 +0x19c
github.com/DataDog/ebpf-manager.(*PerfMap).Start.func1()
	/home/will/go/src/github.com/DataDog/ebpf-manager/perf.go:120 +0xa5
created by github.com/DataDog/ebpf-manager.(*PerfMap).Start
	/home/will/go/src/github.com/DataDog/ebpf-manager/perf.go:108 +0x116
make: *** [Makefile:26: run] Error 2
```

### Describe how to test your changes

Start any example. You should be able to run them normally.