### PR TITLE
update Makefiles to support multiple architectures

### DIFF
--- a/examples/activated_probes/Makefile
+++ b/examples/activated_probes/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/clone_vs_add_hook/Makefile
+++ b/examples/clone_vs_add_hook/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/instruction_patching/Makefile
+++ b/examples/instruction_patching/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/map_rewrite_vs_map_router/Makefile
+++ b/examples/map_rewrite_vs_map_router/Makefile
@@ -1,10 +1,12 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf: build-prog1 build-prog2
 
 build-prog1:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -14,16 +16,16 @@ build-prog1:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/prog1.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe1.o
 
 build-prog2:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -33,9 +35,9 @@ build-prog2:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/prog2.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe2.o

--- a/examples/mapspec_editor/Makefile
+++ b/examples/mapspec_editor/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/object_pinning/Makefile
+++ b/examples/object_pinning/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/program_router/Makefile
+++ b/examples/program_router/Makefile
@@ -1,10 +1,12 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf: build-prog1 build-prog2
 
 build-prog1:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -14,16 +16,16 @@ build-prog1:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/prog1.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe1.o
 
 build-prog2:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -33,9 +35,9 @@ build-prog2:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/prog2.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe2.o

--- a/examples/programs/cgroup/Makefile
+++ b/examples/programs/cgroup/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/programs/fentry/Makefile
+++ b/examples/programs/fentry/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -g -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/programs/kprobe/Makefile
+++ b/examples/programs/kprobe/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/programs/lsm/Makefile
+++ b/examples/programs/lsm/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/programs/perf_event/Makefile
+++ b/examples/programs/perf_event/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/programs/socket/Makefile
+++ b/examples/programs/socket/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/programs/tc/Makefile
+++ b/examples/programs/tc/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/programs/tracepoint/Makefile
+++ b/examples/programs/tracepoint/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/programs/uprobe/Makefile
+++ b/examples/programs/uprobe/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/programs/xdp/Makefile
+++ b/examples/programs/xdp/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o

--- a/examples/tests_and_benchmarks/Makefile
+++ b/examples/tests_and_benchmarks/Makefile
@@ -1,8 +1,10 @@
+ARCH ?= x86
+
 all: build-ebpf build run
 
 build-ebpf:
 	mkdir -p ebpf/bin
-	clang -D__KERNEL__ -D__ASM_SYSREG_H \
+	clang -D__KERNEL__ \
 		-Wno-unused-value \
 		-Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
@@ -12,9 +14,9 @@ build-ebpf:
 		-I/lib/modules/$$(uname -r)/build/include \
 		-I/lib/modules/$$(uname -r)/build/include/uapi \
 		-I/lib/modules/$$(uname -r)/build/include/generated/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/uapi \
-		-I/lib/modules/$$(uname -r)/build/arch/x86/include/generated \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/uapi \
+		-I/lib/modules/$$(uname -r)/build/arch/$(ARCH)/include/generated \
 		-O2 -emit-llvm \
 		ebpf/main.c \
 		-c -o - | llc -march=bpf -filetype=obj -o ebpf/bin/probe.o


### PR DESCRIPTION
### What does this PR do?

Allow override of `ARCH` in Makefiles

### Motivation

Support arm64

### Additional Notes

You have to specify `ARCH=arm64` on the command line, but it works at least.


