### PR TITLE
Fix tests-and-benchmarks example

### DIFF
--- a/examples/tests_and_benchmarks/main.go
+++ b/examples/tests_and_benchmarks/main.go
@@ -28,7 +28,7 @@ var testDataKey = uint32(1)
 var testData = []TestData{
 	{2, 4},
 	{10, 20},
-	{64, 128},
+	{42, 128},
 	{42, 84},
 }
 
@@ -75,6 +75,9 @@ func runtTest(testMap *ebpf.Map, testProg *ebpf.Program) {
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		if data.Input == 42 && data.Output == 128 {
+			logrus.Printf("(failure expected on next test)")
+		}
 		if outLen == 0 {
 			logrus.Printf("%v - PASS", data)
 		} else {
@@ -93,6 +96,9 @@ func runtBenchmark(testMap *ebpf.Map, testProg *ebpf.Program) {
 		outLen, duration, err := testProg.Benchmark(make([]byte, 14), 1000, nil)
 		if err != nil {
 			logrus.Fatal(err)
+		}
+		if data.Input == 42 && data.Output == 128 {
+			logrus.Printf("(failure expected on next benchmark)")
 		}
 		if outLen == 0 {
 			logrus.Printf("%v - PASS (duration: %v)", data, duration)

--- a/examples/tests_and_benchmarks/main.go
+++ b/examples/tests_and_benchmarks/main.go
@@ -28,7 +28,7 @@ var testDataKey = uint32(1)
 var testData = []TestData{
 	{2, 4},
 	{10, 20},
-	{42, 128},
+	{64, 128},
 	{42, 84},
 }
 


### PR DESCRIPTION
### What does this PR do?

The program does `2 * x`, so it should use an input of `64` if it expects `128`.

### Motivation

failing output:
```
INFO[0000] Running tests ...
INFO[0000] { Input:2 Output:4 } - PASS
INFO[0000] { Input:10 Output:20 } - PASS
INFO[0000] { Input:42 Output:128 } - FAIL (checkout /sys/kernel/debug/tracing/trace_pipe to see the logs)
INFO[0000] { Input:42 Output:84 } - PASS
INFO[0000] Running benchmark ...
INFO[0000] { Input:2 Output:4 } - PASS (duration: 7ns)
INFO[0000] { Input:10 Output:20 } - PASS (duration: 7ns)
INFO[0000] { Input:42 Output:128 } - benchmark FAILED (checkout /sys/kernel/debug/tracing/trace_pipe to see the logs)
INFO[0000] { Input:42 Output:84 } - PASS (duration: 7ns)
```


