### PR TITLE
Deprecate EBPFSection from ProbeIdentificationPair

### DIFF
--- a/examples/activated_probes/main.go
+++ b/examples/activated_probes/main.go
@@ -20,26 +20,22 @@ var m1 = &manager.Manager{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "MyVFSMkdir1",
-				EBPFSection:  "kprobe/vfs_mkdir",
 				EBPFFuncName: "kprobe_vfs_mkdir",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/utimes_common",
 				EBPFFuncName: "kprobe_utimes_common",
 			},
 			MatchFuncName: "utimes",
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/vfs_opennnnnn",
 				EBPFFuncName: "kprobe_vfs_opennnnnn",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/exclude",
 				EBPFFuncName: "kprobe_exclude",
 			},
 		},
@@ -51,7 +47,6 @@ var options1 = manager.Options{
 		&manager.ProbeSelector{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "MyVFSMkdir1",
-				EBPFSection:  "kprobe/vfs_mkdir",
 				EBPFFuncName: "kprobe_vfs_mkdir",
 			},
 		},
@@ -60,13 +55,11 @@ var options1 = manager.Options{
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
 						UID:          "MyVFSMkdir1",
-						EBPFSection:  "kprobe/vfs_mkdir",
 						EBPFFuncName: "kprobe_vfs_mkdir",
 					},
 				},
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFSection:  "kprobe/utimes_common",
 						EBPFFuncName: "kprobe_utimes_common",
 					},
 				},
@@ -76,19 +69,16 @@ var options1 = manager.Options{
 			Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFSection:  "kprobe/utimes_common",
 						EBPFFuncName: "kprobe_utimes_common",
 					},
 				},
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFSection:  "kprobe/vfs_opennnnnn",
 						EBPFFuncName: "kprobe_vfs_opennnnnn",
 					},
 				},
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFSection:  "kprobe/exclude",
 						EBPFFuncName: "kprobe_exclude",
 					},
 				},
@@ -98,13 +88,11 @@ var options1 = manager.Options{
 			Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFSection:  "kprobe/vfs_opennnnnn",
 						EBPFFuncName: "kprobe_vfs_opennnnnn",
 					},
 				},
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFSection:  "kprobe/exclude",
 						EBPFFuncName: "kprobe_exclude",
 					},
 				},
@@ -120,26 +108,22 @@ var m2 = &manager.Manager{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "MyVFSMkdir2",
-				EBPFSection:  "kprobe/vfs_mkdir",
 				EBPFFuncName: "kprobe_vfs_mkdir",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/utimes_common",
 				EBPFFuncName: "kprobe_utimes_common",
 			},
 			MatchFuncName: "utimes_common",
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/vfs_opennnnnn",
 				EBPFFuncName: "kprobe_vfs_opennnnnn",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/exclude",
 				EBPFFuncName: "kprobe_exclude",
 			},
 		},
@@ -151,7 +135,6 @@ var options2 = manager.Options{
 		&manager.ProbeSelector{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "MyVFSMkdir2",
-				EBPFSection:  "kprobe/vfs_mkdir",
 				EBPFFuncName: "kprobe_vfs_mkdir",
 			},
 		},
@@ -159,7 +142,6 @@ var options2 = manager.Options{
 			Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFSection:  "kprobe/vfs_opennnnnn",
 						EBPFFuncName: "kprobe_vfs_opennnnnn",
 					},
 				},
@@ -169,13 +151,11 @@ var options2 = manager.Options{
 			Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFSection:  "kprobe/vfs_opennnnnn",
 						EBPFFuncName: "kprobe_vfs_opennnnnn",
 					},
 				},
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFSection:  "kprobe/exclude",
 						EBPFFuncName: "kprobe_exclude",
 					},
 				},
@@ -192,26 +172,22 @@ var m3 = &manager.Manager{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "MyVFSMkdir2",
-				EBPFSection:  "kprobe/vfs_mkdir",
 				EBPFFuncName: "kprobe_vfs_mkdir",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/utimes_common",
 				EBPFFuncName: "kprobe_utimes_common",
 			},
 			MatchFuncName: "utimes_common",
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/vfs_opennnnnn",
 				EBPFFuncName: "kprobe_vfs_opennnnnn",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/exclude",
 				EBPFFuncName: "kprobe_exclude",
 			},
 		},
@@ -225,12 +201,12 @@ func main() {
 	}
 
 	oldID := manager.ProbeIdentificationPair{
-		EBPFSection:  "kprobe/exclude",
 		EBPFFuncName: "kprobe_exclude",
+		UID:          "",
 	}
 	newID := manager.ProbeIdentificationPair{
-		EBPFSection:  "kprobe/exclude2",
 		EBPFFuncName: "kprobe_exclude",
+		UID:          "new",
 	}
 	if err := m1.RenameProbeIdentificationPair(oldID, newID); err != nil {
 		logrus.Fatal(err)
@@ -289,7 +265,7 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	mkdirID := manager.ProbeIdentificationPair{UID: "MyVFSMkdir2", EBPFSection: "kprobe/vfs_mkdir", EBPFFuncName: "kprobe_vfs_mkdir"}
+	mkdirID := manager.ProbeIdentificationPair{UID: "MyVFSMkdir2", EBPFFuncName: "kprobe_vfs_mkdir"}
 	if err := m3.UpdateActivatedProbes([]manager.ProbesSelector{
 		&manager.ProbeSelector{
 			ProbeIdentificationPair: mkdirID,
@@ -298,14 +274,14 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	vfsOpenID := manager.ProbeIdentificationPair{EBPFSection: "kprobe/vfs_opennnnnn", EBPFFuncName: "kprobe_vfs_opennnnnn"}
+	vfsOpenID := manager.ProbeIdentificationPair{EBPFFuncName: "kprobe_vfs_opennnnnn"}
 	vfsOpenProbe, ok := m3.GetProbe(vfsOpenID)
 	if !ok {
-		logrus.Fatal("Failed to find kprobe/vfs_opennnnnn")
+		logrus.Fatal("Failed to find kprobe_vfs_opennnnnn")
 	}
 
 	if vfsOpenProbe.Enabled {
-		logrus.Errorf("kprobe/vfs_opennnnnn should not be enabled")
+		logrus.Errorf("kprobe_vfs_opennnnnn should not be enabled")
 	}
 }
 

--- a/examples/clone_vs_add_hook/demo.go
+++ b/examples/clone_vs_add_hook/demo.go
@@ -13,7 +13,6 @@ func demoClone() error {
 	newProbe := manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          "MySeconHook",
-			EBPFSection:  "kprobe/vfs_mkdir",
 			EBPFFuncName: "kprobe_vfs_mkdir",
 		},
 	}
@@ -43,7 +42,6 @@ func demoAddHook() error {
 	firstRmdir := manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          "FirstRmdir",
-			EBPFSection:  "kprobe/vfs_rmdir",
 			EBPFFuncName: "kprobe_vfs_rmdir",
 		},
 	}
@@ -55,7 +53,6 @@ func demoAddHook() error {
 	secondRmdir := manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          "SecondRmdir",
-			EBPFSection:  "kprobe/vfs_rmdir",
 			EBPFFuncName: "kprobe_vfs_rmdir",
 		},
 	}

--- a/examples/clone_vs_add_hook/main.go
+++ b/examples/clone_vs_add_hook/main.go
@@ -17,7 +17,6 @@ var m = &manager.Manager{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "MyFirstHook",
-				EBPFSection:  "kprobe/vfs_mkdir",
 				EBPFFuncName: "kprobe_vfs_mkdir",
 			},
 			KeepProgramSpec: true,
@@ -25,7 +24,6 @@ var m = &manager.Manager{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "",
-				EBPFSection:  "kretprobe/mkdir",
 				EBPFFuncName: "kretprobe_mkdir",
 			},
 			SyscallFuncName: "mkdir",
@@ -56,7 +54,7 @@ var editors = []manager.ConstantEditor{
 		Value:         uint64(100),
 		FailOnMissing: true,
 		ProbeIdentificationPairs: []manager.ProbeIdentificationPair{
-			{UID: "MyFirstHook", EBPFSection: "kprobe/vfs_mkdir", EBPFFuncName: "kprobe_vfs_mkdir"},
+			{UID: "MyFirstHook", EBPFFuncName: "kprobe_vfs_mkdir"},
 		},
 	},
 	{
@@ -64,7 +62,7 @@ var editors = []manager.ConstantEditor{
 		Value:         uint64(555),
 		FailOnMissing: true,
 		ProbeIdentificationPairs: []manager.ProbeIdentificationPair{
-			{UID: "", EBPFSection: "kprobe/vfs_mkdir", EBPFFuncName: "kprobe_vfs_mkdir"},
+			{UID: "", EBPFFuncName: "kprobe_vfs_mkdir"},
 		},
 	},
 	{

--- a/examples/instruction_patching/main.go
+++ b/examples/instruction_patching/main.go
@@ -21,7 +21,6 @@ var m1 = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/security_socket_create",
 				EBPFFuncName: "kprobe__security_socket_create",
 			},
 		},

--- a/examples/map_rewrite_vs_map_router/main.go
+++ b/examples/map_rewrite_vs_map_router/main.go
@@ -19,7 +19,6 @@ var m1 = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kretprobe/vfs_mkdir",
 				EBPFFuncName: "kretprobe_vfs_mkdir",
 			},
 		},
@@ -30,7 +29,6 @@ var m2 = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/vfs_mkdir",
 				EBPFFuncName: "kprobe_vfs_mkdir",
 			},
 		},

--- a/examples/object_pinning/main.go
+++ b/examples/object_pinning/main.go
@@ -17,28 +17,24 @@ var m = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/mkdirat",
 				EBPFFuncName: "kprobe_mkdirat",
 			},
 			SyscallFuncName: "mkdirat",
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kretprobe/mkdirat",
 				EBPFFuncName: "kretprobe_mkdirat",
 			},
 			SyscallFuncName: "mkdirat",
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/mkdir",
 				EBPFFuncName: "kprobe_mkdir",
 			},
 			SyscallFuncName: "mkdir",
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kretprobe/mkdir",
 				EBPFFuncName: "kretprobe_mkdir",
 			},
 			SyscallFuncName: "mkdir",

--- a/examples/program_router/demo.go
+++ b/examples/program_router/demo.go
@@ -13,7 +13,7 @@ func demoTailCall() error {
 	trigger1()
 	time.Sleep(1 * time.Second)
 
-	prog, _, err := m2.GetProgram(manager.ProbeIdentificationPair{EBPFSection: "classifier/three", EBPFFuncName: "three"})
+	prog, _, err := m2.GetProgram(manager.ProbeIdentificationPair{EBPFFuncName: "three"})
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -24,7 +24,6 @@ func demoTailCall() error {
 			ProgArrayName: "tc_prog_array",
 			Key:           uint32(1),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "classifier/two",
 				EBPFFuncName: "two",
 			},
 		},

--- a/examples/program_router/main.go
+++ b/examples/program_router/main.go
@@ -19,7 +19,6 @@ var m = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "classifier/one",
 				EBPFFuncName: "one",
 			},
 			IfName:           "lo", // change this to the interface index connected to the internet

--- a/examples/programs/cgroup/main.go
+++ b/examples/programs/cgroup/main.go
@@ -16,7 +16,6 @@ var m = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "cgroup_skb/egress",
 				EBPFFuncName: "egress",
 			},
 			CGroupPath: "/sys/fs/cgroup/unified",

--- a/examples/programs/fentry/main.go
+++ b/examples/programs/fentry/main.go
@@ -21,7 +21,6 @@ var m = &manager.Manager{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "MyVFSMkdir",
-				EBPFSection:  "fentry/vfs_mkdir",
 				EBPFFuncName: "vfs_mkdir_enter",
 			},
 		},
@@ -31,7 +30,6 @@ var m = &manager.Manager{
 				// m.CloneProgram for example), or if multiple programs with the exact same section are attaching
 				// at the exact same hook point (using m.AddHook for example, or simply because another manager
 				// on the system is planning on hooking there).
-				EBPFSection:  "fexit/do_mkdirat",
 				EBPFFuncName: "do_mkdirat_exit",
 			},
 			SyscallFuncName: "mkdirat",

--- a/examples/programs/kprobe/main.go
+++ b/examples/programs/kprobe/main.go
@@ -21,14 +21,12 @@ var m = &manager.Manager{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "MyVFSMkdir",
-				EBPFSection:  "kprobe/vfs_mkdir",
 				EBPFFuncName: "kprobe_vfs_mkdir",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "UtimesCommon",
-				EBPFSection:  "kretprobe/utimes_common",
 				EBPFFuncName: "kretprobe_utimes_common",
 			},
 			MatchFuncName:   "utimes",
@@ -40,7 +38,6 @@ var m = &manager.Manager{
 				// m.CloneProgram for example), or if multiple programs with the exact same section are attaching
 				// at the exact same hook point (using m.AddHook for example, or simply because another manager
 				// on the system is planning on hooking there).
-				EBPFSection:  "kretprobe/mkdirat",
 				EBPFFuncName: "kretprobe_mkdirat",
 			},
 			SyscallFuncName: "mkdirat",

--- a/examples/programs/lsm/main.go
+++ b/examples/programs/lsm/main.go
@@ -20,13 +20,11 @@ var m = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "lsm/inode_getattr",
 				EBPFFuncName: "lsm_security_inode_getattr",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "lsm/bpf",
 				EBPFFuncName: "lsm_security_bpf",
 			},
 		},

--- a/examples/programs/perf_event/main.go
+++ b/examples/programs/perf_event/main.go
@@ -20,7 +20,6 @@ var m = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "perf_event/cpu_clock",
 				EBPFFuncName: "perf_event_cpu_clock",
 			},
 			SampleFrequency: 1,

--- a/examples/programs/socket/main.go
+++ b/examples/programs/socket/main.go
@@ -16,7 +16,6 @@ var m = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "socket/sock_filter",
 				EBPFFuncName: "sock_filter",
 			},
 		},

--- a/examples/programs/tc/main.go
+++ b/examples/programs/tc/main.go
@@ -22,7 +22,6 @@ var m = &manager.Manager{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          "MyUID",
-				EBPFSection:  "classifier/egress",
 				EBPFFuncName: "egress",
 			},
 			IfName:           "lo", // change this to the interface connected to the internet
@@ -30,7 +29,6 @@ var m = &manager.Manager{
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "classifier/ingress",
 				EBPFFuncName: "ingress",
 			},
 			IfName:           "lo", // change this to the interface connected to the internet

--- a/examples/programs/tracepoint/main.go
+++ b/examples/programs/tracepoint/main.go
@@ -16,13 +16,11 @@ var m = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/syscalls/sys_enter_mkdirat",
 				EBPFFuncName: "sys_enter_mkdirat",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/my_tracepoint",
 				EBPFFuncName: "my_tracepoint",
 			},
 			TracepointCategory: "sched",

--- a/examples/programs/uprobe/main.go
+++ b/examples/programs/uprobe/main.go
@@ -16,7 +16,6 @@ var m = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "uprobe/readline",
 				EBPFFuncName: "readline",
 			},
 			BinaryPath: "/usr/bin/bash",

--- a/examples/programs/xdp/main.go
+++ b/examples/programs/xdp/main.go
@@ -16,7 +16,6 @@ var m = &manager.Manager{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "xdp/ingress",
 				EBPFFuncName: "ingress",
 			},
 			IfIndex:       2, // change this to the interface index connected to the internet

--- a/examples/tests_and_benchmarks/main.go
+++ b/examples/tests_and_benchmarks/main.go
@@ -48,7 +48,6 @@ func main() {
 	// Get xdp program used to trigger the tests
 	testProgs, found, err := m.GetProgram(
 		manager.ProbeIdentificationPair{
-			EBPFSection:  "xdp/my_func_test",
 			EBPFFuncName: "my_func_test",
 		},
 	)
@@ -68,7 +67,9 @@ func runtTest(testMap *ebpf.Map, testProg *ebpf.Program) {
 	logrus.Println("Running tests ...")
 	for _, data := range testData {
 		// insert data
-		testMap.Put(testDataKey, data)
+		if err := testMap.Put(testDataKey, data); err != nil {
+			logrus.Fatal(err)
+		}
 
 		// Trigger test - (the 14 bytes is for the minimum packet size required to test an XDP program)
 		outLen, _, err := testProg.Test(make([]byte, 14))
@@ -87,7 +88,9 @@ func runtBenchmark(testMap *ebpf.Map, testProg *ebpf.Program) {
 	logrus.Println("Running benchmark ...")
 	for _, data := range testData {
 		// insert data
-		testMap.Put(testDataKey, data)
+		if err := testMap.Put(testDataKey, data); err != nil {
+			logrus.Fatal(err)
+		}
 
 		// Trigger test
 		outLen, duration, err := testProg.Benchmark(make([]byte, 14), 1000, nil)

--- a/manager.go
+++ b/manager.go
@@ -44,7 +44,7 @@ type ConstantEditor struct {
 // TailCallRoute - A tail call route defines how tail calls should be routed between eBPF programs.
 //
 // The provided eBPF program will be inserted in the provided eBPF program array, at the provided key. The eBPF program
-// can be provided by its section or by its *ebpf.Program representation.
+// can be provided by its function name or by its *ebpf.Program representation.
 type TailCallRoute struct {
 	// ProgArrayName - Name of the BPF_MAP_TYPE_PROG_ARRAY map as defined in its section SEC("maps/[ProgArray]")
 	ProgArrayName string
@@ -479,14 +479,14 @@ func (m *Manager) RenameProbeIdentificationPair(oldID ProbeIdentificationPair, n
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
 
-	// sanity check: make sure the newID doesn't already exists
+	// sanity check: make sure the newID doesn't already exist
 	for _, mProbe := range m.Probes {
 		if mProbe.Matches(newID) {
 			return ErrIdentificationPairInUse
 		}
 	}
 
-	if oldID.EBPFSection != newID.EBPFSection {
+	if oldID.EBPFFuncName != newID.EBPFFuncName {
 		// edit the excluded sections
 		for i, excludedFuncName := range m.options.ExcludedFunctions {
 			if excludedFuncName == oldID.EBPFFuncName {
@@ -931,7 +931,7 @@ func (m *Manager) AddHook(UID string, newProbe *Probe) error {
 		return ErrManagerNotInitialized
 	}
 
-	oldID := ProbeIdentificationPair{UID: UID, EBPFSection: newProbe.EBPFSection, EBPFFuncName: newProbe.EBPFFuncName}
+	oldID := ProbeIdentificationPair{UID: UID, EBPFFuncName: newProbe.EBPFFuncName}
 	// Look for the eBPF program
 	progs, found, err := m.getProgram(oldID)
 	if err != nil {
@@ -1005,7 +1005,7 @@ func (m *Manager) DetachHook(id ProbeIdentificationPair) error {
 	}
 
 	// Check how many instances of the program are left in the kernel
-	progs, _, err := m.getProgram(ProbeIdentificationPair{UID: "", EBPFSection: id.EBPFSection, EBPFFuncName: id.EBPFFuncName})
+	progs, _, err := m.getProgram(ProbeIdentificationPair{UID: "", EBPFFuncName: id.EBPFFuncName})
 	if err != nil {
 		return err
 	}
@@ -1047,7 +1047,7 @@ func (m *Manager) CloneProgram(UID string, newProbe *Probe, constantsEditors []C
 		return ErrManagerNotInitialized
 	}
 
-	oldID := ProbeIdentificationPair{UID: UID, EBPFSection: newProbe.EBPFSection, EBPFFuncName: newProbe.EBPFFuncName}
+	oldID := ProbeIdentificationPair{UID: UID, EBPFFuncName: newProbe.EBPFFuncName}
 	var oldProgramSpec *ebpf.ProgramSpec
 	// look for an existing probe
 	oldProbe, found := m.getProbe(oldID)


### PR DESCRIPTION
### What does this PR do?

Deprecates `EBPFSection` from `ProbeIdentificationPair` because `EBPFFuncName` is sufficient and we can obtain the section from `Probe.programSpec.SectionName`

### Motivation

Simpler API


