### PR TITLE
Add check for missing editor flags in mapSpecEditor

### DIFF
--- a/err.go
+++ b/err.go
@@ -25,4 +25,5 @@ var (
 	ErrMapNotRunning            = errors.New("the map is not running")
 	ErrNotSupported             = errors.New("not supported")
 	ErrNoNetworkDirection       = errors.New("a valid network direction is required to attach a TC classifier")
+	ErrMissingEditorFlags       = errors.New("missing editor flags in map editor")
 )

--- a/manager.go
+++ b/manager.go
@@ -1529,6 +1529,9 @@ func (m *Manager) editMapSpecs() error {
 		if !exists {
 			return fmt.Errorf("failed to edit maps/%s: couldn't find map: %w", name, ErrUnknownSection)
 		}
+		if mapEditor.EditorFlag == 0 {
+			return fmt.Errorf("failed to edit maps/%s: %w", name, ErrMissingEditorFlags)
+		}
 		if EditType&mapEditor.EditorFlag == EditType {
 			spec.Type = mapEditor.Type
 		}


### PR DESCRIPTION
### What does this PR do?

This PR adds a check in `editMapSpecs` for missing EditorFlags, providing users of ebpf-manager with a useful error message if so.

### Motivation

Wanted to use a mapSpecEdit for a map to work (e.g changing a map size to a non-zero value), but forgot the flags, causing an `invalid argument` error that left me confused, as I thought I was changing the specs correctly. With this change, ebpf-manager should tell the developer, that they need to provide flags for it to work.
