### PR TITLE
fix `UpdatedActivatedProbes` with potential sections

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1413,15 +1413,17 @@ func (m *Manager) UpdateActivatedProbes(selectors []ProbesSelector) error {
 
 	currentProbes := make(map[ProbeIdentificationPair]*Probe)
 	for _, p := range m.Probes {
+		pip := ProbeIdentificationPair{UID: p.ProbeIdentificationPair.UID, EBPFFuncName: p.ProbeIdentificationPair.EBPFFuncName}
 		if p.Enabled {
-			currentProbes[p.ProbeIdentificationPair] = p
+			currentProbes[pip] = p
 		}
 	}
 
 	nextProbes := make(map[ProbeIdentificationPair]bool)
 	for _, selector := range selectors {
 		for _, id := range selector.GetProbesIdentificationPairList() {
-			nextProbes[id] = true
+			pip := ProbeIdentificationPair{UID: id.UID, EBPFFuncName: id.EBPFFuncName}
+			nextProbes[pip] = true
 		}
 	}
 

--- a/probe.go
+++ b/probe.go
@@ -85,7 +85,7 @@ type ProbeIdentificationPair struct {
 }
 
 func (pip ProbeIdentificationPair) String() string {
-	return fmt.Sprintf("{UID:%s EBPFFuncName:%s}", pip.UID, pip.EBPFFuncName)
+	return fmt.Sprintf("{UID:%s EBPFFuncName:%s EBPFSection:%s}", pip.UID, pip.EBPFFuncName, pip.EBPFSection)
 }
 
 // Matches - Returns true if the identification pair (probe uid, probe section, probe func name) matches.


### PR DESCRIPTION
### What does this PR do?

Since `EBPFSection` is only deprecated but still there, library user can still pass ProbeIdentificationPair containing sections. This can cause issue if the matching is done using OOTB equality (like in a map access for example). This was the case in `UpdateActivatedProbes` causing issue with CWS probe reloading.

This PR also re-enables the display of `EBPFSection` in the `String()` function for probe identification pair since it can cause issues during debugging (you think there is no section, but it's actually false)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
