### PR TITLE
fix data race between selectors and manager

### DIFF
--- a/selectors.go
+++ b/selectors.go
@@ -33,7 +33,7 @@ func (ps *ProbeSelector) GetProbesIdentificationPairList() []ProbeIdentification
 // RunValidator - Ensures that the probes that were successfully activated follow the selector goal.
 // For example, see OneOf.
 func (ps *ProbeSelector) RunValidator(manager *Manager) error {
-	p, ok := manager.getProbe(ps.ProbeIdentificationPair)
+	p, ok := manager.GetProbe(ps.ProbeIdentificationPair)
 	if !ok {
 		return fmt.Errorf("probe not found: %s", ps.ProbeIdentificationPair)
 	}


### PR DESCRIPTION
### What does this PR do?

Here a stack trace

```
       [5.15.57-30.131.amzn2022.x86_64][d] WARNING: DATA RACE
       [5.15.57-30.131.amzn2022.x86_64][d] Write at 0x00c0009bc380 by goroutine 932:
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/ebpf-manager.(*Manager).CloneProgram()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.2.0/manager.go:1129 +0x13e4
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/datadog-agent/pkg/security/probe/resolvers.(*TCResolver).SetupNewTCClassifierWithNetNSHandle()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/resolvers/tc_resolver.go:109 +0x6bd
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/datadog-agent/pkg/security/probe.(*NamespaceResolver).snapshotNetworkDevices()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/namespace_resolver.go:329 +0x67b
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/datadog-agent/pkg/security/probe.(*NamespaceResolver).SaveNetworkNamespaceHandle()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/namespace_resolver.go:272 +0x2fb
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:509 +0x10d4
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent-fm()
       [5.15.57-30.131.amzn2022.x86_64][d] <autogenerated>:1 +0x6d
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/datadog-agent/pkg/security/probe.(*RingBuffer).handleEvent()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/ringbuffer.go:54 +0x6e
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/datadog-agent/pkg/security/probe.(*RingBuffer).handleEvent-fm()
       [5.15.57-30.131.amzn2022.x86_64][d] <autogenerated>:1 +0x87
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/ebpf-manager.(*RingBuffer).Start.func1()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.2.0/ringbuffer.go:100 +0x136
       [5.15.57-30.131.amzn2022.x86_64][d] 
       [5.15.57-30.131.amzn2022.x86_64][d] Previous read at 0x00c0009bc380 by goroutine 920:
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/ebpf-manager.(*Manager).getProbe()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.2.0/manager.go:467 +0xa9
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/ebpf-manager.(*ProbeSelector).RunValidator()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.2.0/selectors.go:36 +0x46
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/ebpf-manager.(*OneOf).RunValidator()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.2.0/selectors.go:79 +0x1a8
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/ebpf-manager.(*Manager).Start()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.2.0/manager.go:701 +0x745
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Setup()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:289 +0x47
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/datadog-agent/pkg/security/module.(*Module).Start()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:139 +0x6c
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:861 +0x1d51
       [5.15.57-30.131.amzn2022.x86_64][d] github.com/DataDog/datadog-agent/pkg/security/tests.TestProcessEnvsWithValue()
       [5.15.57-30.131.amzn2022.x86_64][d] /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/process_test.go:962 +0x2fe
       [5.15.57-30.131.amzn2022.x86_64][d] testing.tRunner()
       [5.15.57-30.131.amzn2022.x86_64][d] /root/.gimme/versions/go1.19.5.linux.amd64/src/testing/testing.go:1446 +0x216
       [5.15.57-30.131.amzn2022.x86_64][d] testing.(*T).Run.func1()
       [5.15.57-30.131.amzn2022.x86_64][d] /root/.gimme/versions/go1.19.5.linux.amd64/src/testing/testing.go:1493 +0x47
       [5.15.57-30.131.amzn2022.x86_64][d]
```


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
