### PR TITLE
Expose full verifier log on error

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -1666,6 +1667,11 @@ func (m *Manager) loadCollection() error {
 	// Load collection
 	m.collection, err = ebpf.NewCollectionWithOptions(m.collectionSpec, m.options.VerifierOptions)
 	if err != nil {
+		var ve *ebpf.VerifierError
+		if errors.As(err, &ve) {
+			// include error twice to preserve context, and still allow unwrapping if desired
+			return fmt.Errorf("verifier error loading eBPF programs: %w\n%+v", err, ve)
+		}
 		return fmt.Errorf("couldn't load eBPF programs: %w", err)
 	}
 

--- a/manager_test.go
+++ b/manager_test.go
@@ -1,0 +1,41 @@
+package manager
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/rlimit"
+)
+
+func TestVerifierError(t *testing.T) {
+	err := rlimit.RemoveMemlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{
+		collectionSpec: &ebpf.CollectionSpec{
+			Programs: map[string]*ebpf.ProgramSpec{"socket__filter": {
+				Type: ebpf.SocketFilter,
+				Instructions: asm.Instructions{
+					asm.LoadImm(asm.R0, 0, asm.DWord),
+					// Missing Return
+				},
+				License: "MIT",
+			}},
+		},
+	}
+	err = m.loadCollection()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var ve *ebpf.VerifierError
+	if !errors.As(err, &ve) {
+		t.Fatal("expected to be able to unwrap to VerifierError")
+	}
+	if strings.Count(err.Error(), "\n") == 0 {
+		t.Fatal("expected full verifier error")
+	}
+}

--- a/probe.go
+++ b/probe.go
@@ -441,6 +441,11 @@ func (p *Probe) internalInit() error {
 		prog, err := ebpf.NewProgramWithOptions(p.programSpec, p.manager.options.VerifierOptions.Programs)
 		if err != nil {
 			p.lastError = err
+			var ve *ebpf.VerifierError
+			if errors.As(err, &ve) {
+				// include error twice to preserve context, and still allow unwrapping if desired
+				return fmt.Errorf("verifier error loading new probe %v: %w\n%+v", p.ProbeIdentificationPair, err, ve)
+			}
 			return fmt.Errorf("couldn't load new probe %v: %w", p.ProbeIdentificationPair, err)
 		}
 		p.program = prog


### PR DESCRIPTION
### What does this PR do?

If a verifier error is encountered on load, we output the full log in the error string rather than only 1-2 lines. We keep the abbreviated version in the first line as `%w` to allow consumers to unwrap the error if desired.
