### PR TITLE
unexport netlink socket cache

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -2023,7 +2023,7 @@ func cleanupUprobeEvents(pattern *regexp.Regexp, pidMask map[int]procMask) error
 }
 
 func (m *Manager) GetNetlinkSocket(nsHandle uint64, nsID uint32) (*NetlinkSocket, error) {
-	return m.netlinkSocketCache.GetNetlinkSocket(nsHandle, nsID)
+	return m.netlinkSocketCache.getNetlinkSocket(nsHandle, nsID)
 }
 
 type netlinkSocketCache struct {

--- a/manager.go
+++ b/manager.go
@@ -228,7 +228,7 @@ type Manager struct {
 	collectionSpec     *ebpf.CollectionSpec
 	collection         *ebpf.Collection
 	options            Options
-	netlinkSocketCache *NetlinkSocketCache
+	netlinkSocketCache *netlinkSocketCache
 	state              state
 	stateLock          sync.RWMutex
 
@@ -532,7 +532,7 @@ func (m *Manager) InitWithOptions(elf io.ReaderAt, options Options) error {
 
 	m.wg = &sync.WaitGroup{}
 	m.options = options
-	m.netlinkSocketCache = NewNetlinkSocketCache()
+	m.netlinkSocketCache = newNetlinkSocketCache()
 	if m.options.DefaultPerfRingBufferSize == 0 {
 		m.options.DefaultPerfRingBufferSize = os.Getpagesize()
 	}
@@ -2026,24 +2026,24 @@ func (m *Manager) GetNetlinkSocket(nsHandle uint64, nsID uint32) (*NetlinkSocket
 	return m.netlinkSocketCache.GetNetlinkSocket(nsHandle, nsID)
 }
 
-type NetlinkSocketCache struct {
+type netlinkSocketCache struct {
 	sync.Mutex
 	cache map[uint32]*NetlinkSocket
 }
 
-func NewNetlinkSocketCache() *NetlinkSocketCache {
-	return &NetlinkSocketCache{
+func newNetlinkSocketCache() *netlinkSocketCache {
+	return &netlinkSocketCache{
 		cache: make(map[uint32]*NetlinkSocket),
 	}
 }
 
-// GetNetlinkSocket - Returns a netlink socket in the requested network namespace from cache or creates a new one.
+// getNetlinkSocket - Returns a netlink socket in the requested network namespace from cache or creates a new one.
 // TC classifiers are attached by creating a qdisc on the requested interface. A netlink socket
 // is required to create a qdisc (or to attach an XDP program to an interface). Since this socket can be re-used for
 // multiple probes, instantiate the connection at the manager level and cache the netlink socket. The provided nsID
 // should be the ID of the network namespaced returned by a readlink on `/proc/[pid]/ns/net` for a [pid] that lives in
 // the network namespace pointed to by the nsHandle.
-func (nsc *NetlinkSocketCache) GetNetlinkSocket(nsHandle uint64, nsID uint32) (*NetlinkSocket, error) {
+func (nsc *netlinkSocketCache) getNetlinkSocket(nsHandle uint64, nsID uint32) (*NetlinkSocket, error) {
 	nsc.Lock()
 	defer nsc.Unlock()
 
@@ -2063,7 +2063,7 @@ func (nsc *NetlinkSocketCache) GetNetlinkSocket(nsHandle uint64, nsID uint32) (*
 
 // cleanup - Cleans up all opened netlink sockets in cache. This function is expected to be called when a
 // manager is stopped.
-func (nsc *NetlinkSocketCache) cleanup() {
+func (nsc *netlinkSocketCache) cleanup() {
 	nsc.Lock()
 	defer nsc.Unlock()
 
@@ -2074,7 +2074,7 @@ func (nsc *NetlinkSocketCache) cleanup() {
 	}
 }
 
-func (nsc *NetlinkSocketCache) remove(nsID uint32) {
+func (nsc *netlinkSocketCache) remove(nsID uint32) {
 	s, ok := nsc.cache[nsID]
 	if ok {
 		delete(nsc.cache, nsID)

--- a/probe.go
+++ b/probe.go
@@ -137,7 +137,7 @@ const (
 // Probe - Main eBPF probe wrapper. This structure is used to store the required data to attach a loaded eBPF
 // program to its hook point.
 type Probe struct {
-	netlinkSocketCache      *NetlinkSocketCache
+	netlinkSocketCache      *netlinkSocketCache
 	program                 *ebpf.Program
 	programSpec             *ebpf.ProgramSpec
 	perfEventFD             *fd
@@ -812,7 +812,7 @@ func (p *Probe) reset() {
 
 // getNetlinkSocket returns a netlink socket in the probe network namespace
 func (p *Probe) getNetlinkSocket() (*NetlinkSocket, error) {
-	return p.netlinkSocketCache.GetNetlinkSocket(p.IfIndexNetns, p.IfIndexNetnsID)
+	return p.netlinkSocketCache.getNetlinkSocket(p.IfIndexNetns, p.IfIndexNetnsID)
 }
 
 // attachWithKprobeEvents attaches the kprobe using the kprobes_events ABI


### PR DESCRIPTION
### What does this PR do?

Fix wrong export of internal cache added in https://github.com/DataDog/ebpf-manager/pull/88

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
