### PR TITLE
implement `CopyProbeIdentificationPair` function for probe

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -357,6 +357,13 @@ func (p *Probe) Copy() *Probe {
 	}
 }
 
+// CopyProbeIdentificationPair is a thread safe function allowing to copy the probe identification pair
+func (p *Probe) CopyProbeIdentificationPair() ProbeIdentificationPair {
+	p.stateLock.RLock()
+	defer p.stateLock.RUnlock()
+	return p.ProbeIdentificationPair
+}
+
 // GetLastError - Returns the last error that the probe encountered
 func (p *Probe) GetLastError() error {
 	return p.lastError


### PR DESCRIPTION
### What does this PR do?

The test run https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/233267251 shows a potential data race between `(*Probe).reset()` (locking) and a read access to `(*Probe).ProbeIdentificationPair`. 

This PR implements a new `CopyProbeIdentificationPair` read-locking and returning a copy of the identification pair.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
