### PR TITLE
Add ability to pause/resume probes

### DIFF
--- a/syscalls.go
+++ b/syscalls.go
@@ -105,12 +105,23 @@ func perfEventOpenRaw(attr *unix.PerfEventAttr, pid int, cpu int, groupFd int, f
 	return newFD(uint32(efd)), nil
 }
 
-func ioctlPerfEventEnable(perfEventOpenFD *fd, progFD int) error {
+func ioctlPerfEventSetBPF(perfEventOpenFD *fd, progFD int) error {
 	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_SET_BPF, uintptr(progFD)); err != 0 {
 		return fmt.Errorf("error attaching bpf program to perf event: %w", err)
 	}
+	return nil
+}
+
+func ioctlPerfEventEnable(perfEventOpenFD *fd) error {
 	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_ENABLE, 0); err != 0 {
 		return fmt.Errorf("error enabling perf event: %w", err)
+	}
+	return nil
+}
+
+func ioctlPerfEventDisable(perfEventOpenFD *fd) error {
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_DISABLE, 0); err != 0 {
+		return fmt.Errorf("error disabling perf event: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Adds `Pause()` and `Resume()` functions to probes and the manager. Currently supports kprobes, socket filters, and tracepoints.

### Motivation

This allows us to pause and resume eBPF functionality without destroying/re-creating the manager which can take a (relatively) long time. This is primarily motivated by tests.

### Additional Notes

This does not clear any state from eBPF maps.

### Describe how to test your changes

Tested with the datadog-agent.
