### PR TITLE
Allow debugfs magic value for /sys/kernel/debug/tracing

### DIFF
--- a/tracefs/tracefs.go
+++ b/tracefs/tracefs.go
@@ -37,16 +37,16 @@ func getRoot() (string, error) {
 		}
 		var debugError error
 		if debugError = unix.Statfs(debugFSRoot, &statfs); debugError == nil {
-			if statfs.Type == unix.TRACEFS_MAGIC {
+			if statfs.Type == unix.TRACEFS_MAGIC || statfs.Type == unix.DEBUGFS_MAGIC {
 				tracingRoot.path = debugFSRoot
 				return
 			}
-			debugError = fmt.Errorf("%s is not mounted with tracefs filesystem type", debugFSRoot)
+			debugError = fmt.Errorf("%s is not mounted with tracefs or debugfs filesystem type", debugFSRoot)
 		}
 
 		bestError := fmt.Errorf("tracefs: %s", traceError)
 		// only fallback to debugfs error if tracefs doesn't exist at all and debugfs does
-		if errors.Is(traceError, syscall.ENOTDIR) && !errors.Is(debugError, syscall.ENOTDIR) {
+		if errors.Is(traceError, syscall.ENOENT) && !errors.Is(debugError, syscall.ENOENT) {
 			bestError = fmt.Errorf("debugfs: %s", debugError)
 		}
 		tracingRoot.err = fmt.Errorf("tracefs or debugfs is not available: %s", bestError)


### PR DESCRIPTION
### What does this PR do?

Allows either the `tracefs` or `debugfs` for `/sys/kernel/debug/tracing`

### Motivation

CentOS 7.6 doesn't mount `/sys/kernel/debug/tracing` as tracefs

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
