### PR TITLE
Export eBPF maps from the `Collection` of a manager

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -336,6 +336,16 @@ func (m *Manager) GetMap(name string) (*ebpf.Map, bool, error) {
 	return m.getMap(name)
 }
 
+// GetMaps - Return the list of eBPF maps in the manager
+func (m *Manager) GetMaps() (map[string]*ebpf.Map, error) {
+	m.stateLock.RLock()
+	defer m.stateLock.RUnlock()
+	if m.collection == nil || m.state < initialized {
+		return nil, ErrManagerNotInitialized
+	}
+	return m.collection.Maps, nil
+}
+
 // getMapSpec - Thread unsafe version of GetMapSpec
 func (m *Manager) getMapSpec(name string) (*ebpf.MapSpec, bool, error) {
 	eBPFMap, ok := m.collectionSpec.Maps[name]


### PR DESCRIPTION
### What does this PR do?

This PR exports the list of internal eBPF maps from the `Collection` attribute of a `manager`.

### Motivation

The CWS agent needs to be able to list its underlying maps that are in use at runtime for 2 use cases:
- making sure that all maps are shared between its multiple managers
- listing the maps names in use at runtime, this will soon be needed in order to write CWS rules to protect the agent itself

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
