### PR TITLE
make nil `*ProbeSelector` a first class citizen

### DIFF
--- a/selectors.go
+++ b/selectors.go
@@ -27,6 +27,10 @@ type ProbeSelector struct {
 
 // GetProbesIdentificationPairList - Returns the list of probes that this selector activates
 func (ps *ProbeSelector) GetProbesIdentificationPairList() []ProbeIdentificationPair {
+	if ps == nil {
+		return nil
+	}
+
 	return []ProbeIdentificationPair{ps.ProbeIdentificationPair}
 }
 

--- a/selectors.go
+++ b/selectors.go
@@ -37,6 +37,10 @@ func (ps *ProbeSelector) GetProbesIdentificationPairList() []ProbeIdentification
 // RunValidator - Ensures that the probes that were successfully activated follow the selector goal.
 // For example, see OneOf.
 func (ps *ProbeSelector) RunValidator(manager *Manager) error {
+	if ps == nil {
+		return nil
+	}
+
 	p, ok := manager.GetProbe(ps.ProbeIdentificationPair)
 	if !ok {
 		return fmt.Errorf("probe not found: %s", ps.ProbeIdentificationPair)


### PR DESCRIPTION
### What does this PR do?

This PR adds support to a nil `*ProbeSelector`, it's basically something that will amount to 0 probes and will always validate successfully.

This allows function to return `*ProbeSelector` and use it directly, most useful in arrays literal:
```
func f(n string) *ProbeSelector

a := []*ProbeSelector {
  f("b"),
  f("c"),
}
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
