### PR TITLE
Add uprobe attach method option

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -191,6 +191,9 @@ type Options struct {
 	// DefaultKprobeAttachMethod - Manager-level default value for the Kprobe attach method. Defaults to AttachKprobeWithPerfEventOpen if unset.
 	DefaultKprobeAttachMethod KprobeAttachMethod
 
+	// DefaultUprobeAttachMethod - Manager-level default value for the Uprobe attach method. Defaults to AttachWithPerfEventOpen if unset.
+	DefaultUprobeAttachMethod AttachMethod
+
 	// ProbeRetry - Defines the number of times that a probe will retry to attach / detach on error.
 	DefaultProbeRetry uint
 


### PR DESCRIPTION
### What does this PR do?

Adds an equivalent option to uprobes for choosing the attachment method, as kprobes already have.
