### PR TITLE
add an option to skip starting perf/ringbuffer goroutines

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -714,7 +714,7 @@ func (m *Manager) Start() error {
 
 	// Start perf ring readers
 	for _, perfRing := range m.PerfMaps {
-		if skip, _ := m.options.SkipPerfMapReaderStartup[perfRing.Name]; skip {
+		if m.options.SkipPerfMapReaderStartup[perfRing.Name] {
 			continue
 		}
 		if err := perfRing.Start(); err != nil {
@@ -727,7 +727,7 @@ func (m *Manager) Start() error {
 
 	// Start ring buffer readers
 	for _, ringBuffer := range m.RingBuffers {
-		if skip, _ := m.options.SkipRingbufferReaderStartup[ringBuffer.Name]; skip {
+		if m.options.SkipRingbufferReaderStartup[ringBuffer.Name] {
 			continue
 		}
 		if err := ringBuffer.Start(); err != nil {


### PR DESCRIPTION
### What does this PR do?

Add `SkipPerfMapReaderStartup` and `SkipRingbufferReaderStartup` options.

### Motivation

The manager's `Start()` function handles both attaching eBPF programs and starting goroutines that read events from perf and ringbuffer maps. Adding these options makes it possible to decouple the two and start reading events after the manager has been started.