### PR TITLE
Add GetPrograms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/vishvananda/netlink v1.1.1-0.20220316193741-b112db377d18
 	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/sys v0.8.0
 )
 
@@ -19,5 +20,4 @@ require (
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 )

--- a/manager.go
+++ b/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+	"golang.org/x/exp/maps"
 	"golang.org/x/sys/unix"
 )
 
@@ -460,6 +461,17 @@ func (m *Manager) GetProgram(id ProbeIdentificationPair) ([]*ebpf.Program, bool,
 		return nil, false, ErrManagerNotInitialized
 	}
 	return m.getProgram(id)
+}
+
+// GetPrograms - Return the list of eBPF programs in the manager
+func (m *Manager) GetPrograms() (map[string]*ebpf.Program, error) {
+	m.stateLock.RLock()
+	defer m.stateLock.RUnlock()
+	if m.collection == nil || m.state < initialized {
+		return nil, ErrManagerNotInitialized
+	}
+
+	return maps.Clone(m.collection.Programs), nil
 }
 
 // getProgramSpec - Thread unsafe version of GetProgramSpec


### PR DESCRIPTION
### What does this PR do?

Adds `GetPrograms()` to manager.

### Motivation

Like `GetMaps()`, I needed a way to get all the loaded eBPF programs. Iterating through `Probes` does not include the tail-called programs.

