### PR TITLE
Omit excluded `Probes` when listing `ProgramSpecs`

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1606,7 +1606,7 @@ func (m *Manager) editConstants() error {
 
 		// newEditor the constant of the provided programs
 		for _, id := range constantEditor.ProbeIdentificationPairs {
-			if probeIsExcluded(id, m.options.ExcludedFunctions) {
+			if probe, ok := m.GetProbe(id); ok && probeIsExcluded(probe, m.options.ExcludedFunctions) {
 				continue
 			}
 


### PR DESCRIPTION
### What does this PR do?
The `ProgramSpec` for `ExcludedFunctions` are deleted when initializing.
However, `GetProgramSpec` does not account for this and returns nil values.

This can cause panic on other control flows.

For example when constant patching with targeted `ProbeIdentificationPairs`  we run into a panic because `GetProgramSpec` returns nil values.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
