### PR TITLE
add `RunWhileLocked` on manager to safely operate on maps

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -2008,6 +2008,15 @@ func (m *Manager) CleanupNetworkNamespace(nsID uint32) error {
 	return err
 }
 
+// RunWhileLocked allows to call a function with the state lock on the manager taken
+// since most public functions of manager take the lock as well they should not be called from there
+// the main use case is to operate on maps, while ensuring the manager will not close during the operation
+func (m *Manager) RunWhileLocked(callback func() error) error {
+	m.stateLock.Lock()
+	defer m.stateLock.Unlock()
+	return callback()
+}
+
 type procMask uint8
 
 const (


### PR DESCRIPTION
### What does this PR do?

When doing operation on `ebpf.Maps` you can have data races if the manager is closed by another goroutine at the same time.

To solve this issue this PR adds a new `RunWhileLocked` that allows to run some operation while taking the manager state lock.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
