### PR TITLE
add stateful dynamic function excluder

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -125,8 +125,11 @@ type MapSpecEditor struct {
 	EditorFlag MapSpecEditorFlag
 }
 
+// FunctionExcluder - An interface for types that can be used for `AdditionalExcludedFunctionCollector`
 type FunctionExcluder interface {
+	// ShouldExcludeFunction - Returns true if the function should be excluded
 	ShouldExcludeFunction(name, attachPoint string) bool
+	// CleanCaches - Is called when the manager is done with the excluder (for memory reclaiming for example)
 	CleanCaches()
 }
 
@@ -145,6 +148,7 @@ type Options struct {
 	// deactivated.
 	ExcludedFunctions []string
 
+	// AdditionalExcludedFunctionCollector - A dynamic function excluder, allowing to exclude functions based on the attach point
 	AdditionalExcludedFunctionCollector FunctionExcluder
 
 	// ExcludedMaps - A list of maps that should not be created.

--- a/manager.go
+++ b/manager.go
@@ -622,7 +622,7 @@ func (m *Manager) InitWithOptions(elf io.ReaderAt, options Options) error {
 
 	if m.options.AdditionalExcludedFunctionCollector != nil {
 		for key, prog := range m.collectionSpec.Programs {
-			if prog.AttachTo != "" && m.options.AdditionalExcludedFunctionCollector.ShouldExcludeFunction(key, prog) {
+			if m.options.AdditionalExcludedFunctionCollector.ShouldExcludeFunction(key, prog) {
 				m.options.ExcludedFunctions = append(m.options.ExcludedFunctions, key)
 			}
 		}

--- a/manager.go
+++ b/manager.go
@@ -1528,8 +1528,10 @@ func (m *Manager) UpdateActivatedProbes(selectors []ProbesSelector) error {
 	nextProbes := make(map[ProbeIdentificationPair]bool)
 	for _, selector := range selectors {
 		for _, id := range selector.GetProbesIdentificationPairList() {
-			pip := ProbeIdentificationPair{UID: id.UID, EBPFFuncName: id.EBPFFuncName}
-			nextProbes[pip] = true
+			if !slices.Contains(m.options.ExcludedFunctions, id.EBPFFuncName) {
+				pip := ProbeIdentificationPair{UID: id.UID, EBPFFuncName: id.EBPFFuncName}
+				nextProbes[pip] = true
+			}
 		}
 	}
 

--- a/manager.go
+++ b/manager.go
@@ -128,7 +128,7 @@ type MapSpecEditor struct {
 // FunctionExcluder - An interface for types that can be used for `AdditionalExcludedFunctionCollector`
 type FunctionExcluder interface {
 	// ShouldExcludeFunction - Returns true if the function should be excluded
-	ShouldExcludeFunction(name, attachPoint string) bool
+	ShouldExcludeFunction(name string, prog *ebpf.ProgramSpec) bool
 	// CleanCaches - Is called when the manager is done with the excluder (for memory reclaiming for example)
 	CleanCaches()
 }
@@ -622,7 +622,7 @@ func (m *Manager) InitWithOptions(elf io.ReaderAt, options Options) error {
 
 	if m.options.AdditionalExcludedFunctionCollector != nil {
 		for key, prog := range m.collectionSpec.Programs {
-			if prog.AttachTo != "" && m.options.AdditionalExcludedFunctionCollector.ShouldExcludeFunction(key, prog.AttachTo) {
+			if prog.AttachTo != "" && m.options.AdditionalExcludedFunctionCollector.ShouldExcludeFunction(key, prog) {
 				m.options.ExcludedFunctions = append(m.options.ExcludedFunctions, key)
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to allow to exclude functions dynamically, for example based on some presence in `/proc/kallsyms`, in some `btf` code or other.

To allow this, this PR adds a new option field for the manager pointing to a stateful excluder that can register new excluded functions at init time. This PR also ensures that excluded probes are not attached/init when updating activated probes.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
