### PR TITLE
Fix missing include in constant_editor

### DIFF
--- a/examples/constant_editor/ebpf/main.c
+++ b/examples/constant_editor/ebpf/main.c
@@ -1,5 +1,6 @@
 #include "all.h"
 #include <uapi/linux/bpf.h>
+#include <linux/user_namespace.h>
 
 #define LOAD_CONSTANT(param, var) asm("%0 = " param " ll" : "=r"(var))
 


### PR DESCRIPTION
### What does this PR do?

Fix missing include in constant_editor