### PR TITLE
embed *Map to avoid mutex copy

### DIFF
--- a/examples/clone_vs_add_hook/main.go
+++ b/examples/clone_vs_add_hook/main.go
@@ -31,7 +31,7 @@ var m = &manager.Manager{
 	},
 	PerfMaps: []*manager.PerfMap{
 		{
-			Map: manager.Map{
+			Map: &manager.Map{
 				Name: "my_constants",
 			},
 			PerfMapOptions: manager.PerfMapOptions{

--- a/manager.go
+++ b/manager.go
@@ -1887,7 +1887,7 @@ func (m *Manager) loadPinnedObjects() error {
 		if perfMap.PinPath == "" {
 			continue
 		}
-		if err := m.loadPinnedMap(&perfMap.Map); err != nil {
+		if err := m.loadPinnedMap(perfMap.Map); err != nil {
 			if err == ErrPinnedObjectNotFound {
 				continue
 			}
@@ -1900,7 +1900,7 @@ func (m *Manager) loadPinnedObjects() error {
 		if ringBuffer.PinPath == "" {
 			continue
 		}
-		if err := m.loadPinnedMap(&ringBuffer.Map); err != nil {
+		if err := m.loadPinnedMap(ringBuffer.Map); err != nil {
 			if err == ErrPinnedObjectNotFound {
 				continue
 			}

--- a/perf.go
+++ b/perf.go
@@ -44,7 +44,7 @@ type PerfMap struct {
 	wgReader   sync.WaitGroup
 
 	// Map - A PerfMap has the same features as a normal Map
-	Map
+	*Map
 	PerfMapOptions
 }
 
@@ -58,7 +58,7 @@ func loadNewPerfMap(spec ebpf.MapSpec, options MapOptions, perfOptions PerfMapOp
 
 	// Create the new map
 	perfMap := PerfMap{
-		Map:            *innerMap, //nolint:govet
+		Map:            innerMap,
 		PerfMapOptions: perfOptions,
 	}
 	return &perfMap, nil

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -27,7 +27,7 @@ type RingBuffer struct {
 	wgReader   sync.WaitGroup
 
 	// Map - A PerfMap has the same features as a normal Map
-	Map
+	*Map
 	RingBufferOptions
 }
 
@@ -41,7 +41,7 @@ func loadNewRingBuffer(spec ebpf.MapSpec, options MapOptions, ringBufferOptions 
 
 	// Create the new map
 	ringBuffer := RingBuffer{
-		Map:               *innerMap, //nolint:govet
+		Map:               innerMap,
 		RingBufferOptions: ringBufferOptions,
 	}
 	return &ringBuffer, nil


### PR DESCRIPTION
### What does this PR do?

embed `*Map` to avoid mutex copy

### Motivation

Fix linting error

### Additional Notes

This does technically change the API, but it is an easy fix to add `&` where necessary.
