### PR TITLE
Remove EBPFSection and make ProbeIdentificationPair comparable

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -451,7 +451,7 @@ func (m *Manager) getProgram(id ProbeIdentificationPair) ([]*ebpf.Program, bool,
 	var programs []*ebpf.Program
 	if id.UID == "" {
 		for _, probe := range m.Probes {
-			if probe.EBPFDefinitionMatches(id) {
+			if probe.EBPFFuncName == id.EBPFFuncName {
 				programs = append(programs, probe.program)
 			}
 		}
@@ -462,7 +462,7 @@ func (m *Manager) getProgram(id ProbeIdentificationPair) ([]*ebpf.Program, bool,
 		return []*ebpf.Program{prog}, ok, nil
 	}
 	for _, probe := range m.Probes {
-		if probe.Matches(id) {
+		if probe.ProbeIdentificationPair == id {
 			return []*ebpf.Program{probe.program}, true, nil
 		}
 	}
@@ -498,7 +498,7 @@ func (m *Manager) getProgramSpec(id ProbeIdentificationPair) ([]*ebpf.ProgramSpe
 	var programs []*ebpf.ProgramSpec
 	if id.UID == "" {
 		for _, probe := range m.Probes {
-			if probe.EBPFDefinitionMatches(id) {
+			if probe.EBPFFuncName == id.EBPFFuncName {
 				programs = append(programs, probe.programSpec)
 			}
 		}
@@ -509,7 +509,7 @@ func (m *Manager) getProgramSpec(id ProbeIdentificationPair) ([]*ebpf.ProgramSpe
 		return []*ebpf.ProgramSpec{prog}, ok, nil
 	}
 	for _, probe := range m.Probes {
-		if probe.Matches(id) {
+		if probe.ProbeIdentificationPair == id {
 			return []*ebpf.ProgramSpec{probe.programSpec}, true, nil
 		}
 	}
@@ -532,7 +532,7 @@ func (m *Manager) GetProgramSpec(id ProbeIdentificationPair) ([]*ebpf.ProgramSpe
 // getProbe - Thread unsafe version of GetProbe
 func (m *Manager) getProbe(id ProbeIdentificationPair) (*Probe, bool) {
 	for _, managerProbe := range m.Probes {
-		if managerProbe.Matches(id) {
+		if managerProbe.ProbeIdentificationPair == id {
 			return managerProbe, true
 		}
 	}
@@ -554,7 +554,7 @@ func (m *Manager) RenameProbeIdentificationPair(oldID ProbeIdentificationPair, n
 
 	// sanity check: make sure the newID doesn't already exist
 	for _, mProbe := range m.Probes {
-		if mProbe.Matches(newID) {
+		if mProbe.ProbeIdentificationPair == newID {
 			return ErrIdentificationPairInUse
 		}
 	}
@@ -1186,7 +1186,7 @@ func (m *Manager) DetachHook(id ProbeIdentificationPair) error {
 	// Look for the probe
 	idToDelete := -1
 	for mID, mProbe := range m.Probes {
-		if mProbe.Matches(id) {
+		if mProbe.ProbeIdentificationPair == id {
 			// Detach or stop the probe depending on shouldStop
 			if shouldStop {
 				if err = mProbe.Stop(); err != nil {
@@ -1526,7 +1526,7 @@ func (m *Manager) activateProbes() {
 		shouldActivate := shouldPopulateActivatedProbes
 		for _, selector := range m.options.ActivatedProbes {
 			for _, p := range selector.GetProbesIdentificationPairList() {
-				if mProbe.Matches(p) {
+				if mProbe.ProbeIdentificationPair == p {
 					shouldActivate = true
 				}
 			}

--- a/probe.go
+++ b/probe.go
@@ -72,15 +72,9 @@ type ProbeIdentificationPair struct {
 
 	// EBPFFuncName - Name of the main eBPF function of your eBPF program.
 	EBPFFuncName string
-
-	// EBPFSection - Section in which EBPFFuncName lives.
-	//
-	// Deprecated: Only EBPFFuncName is necessary
-	EBPFSection string
 }
 
 func (pip ProbeIdentificationPair) String() string {
-	return fmt.Sprintf("{UID:%s EBPFFuncName:%s EBPFSection:%s}", pip.UID, pip.EBPFFuncName, pip.EBPFSection)
 }
 
 // Matches - Returns true if the identification pair (probe uid, probe section, probe func name) matches.
@@ -91,6 +85,7 @@ func (pip ProbeIdentificationPair) Matches(id ProbeIdentificationPair) bool {
 // EBPFDefinitionMatches - Returns true if the eBPF definition matches.
 func (pip ProbeIdentificationPair) EBPFDefinitionMatches(id ProbeIdentificationPair) bool {
 	return pip.EBPFFuncName == id.EBPFFuncName
+	return fmt.Sprintf("{UID:%s EBPFFuncName:%s}", pip.UID, pip.EBPFFuncName)
 }
 
 // GetKprobeType - Identifies the probe type of the provided KProbe section

--- a/probe.go
+++ b/probe.go
@@ -63,8 +63,6 @@ const (
 )
 
 type ProbeIdentificationPair struct {
-	kprobeType string
-
 	// UID - (optional) this field can be used to identify your probes when the same eBPF program is used on multiple
 	// hook points. Keep in mind that the pair (probe section, probe UID) needs to be unique
 	// system-wide for the kprobes and uprobes registration to work.
@@ -75,16 +73,6 @@ type ProbeIdentificationPair struct {
 }
 
 func (pip ProbeIdentificationPair) String() string {
-}
-
-// Matches - Returns true if the identification pair (probe uid, probe section, probe func name) matches.
-func (pip ProbeIdentificationPair) Matches(id ProbeIdentificationPair) bool {
-	return pip.UID == id.UID && pip.EBPFDefinitionMatches(id)
-}
-
-// EBPFDefinitionMatches - Returns true if the eBPF definition matches.
-func (pip ProbeIdentificationPair) EBPFDefinitionMatches(id ProbeIdentificationPair) bool {
-	return pip.EBPFFuncName == id.EBPFFuncName
 	return fmt.Sprintf("{UID:%s EBPFFuncName:%s}", pip.UID, pip.EBPFFuncName)
 }
 
@@ -150,6 +138,7 @@ type Probe struct {
 	kprobeHookPointNotExist bool
 	systemWideID            int
 	programTag              string
+	kprobeType              string
 	link                    netlink.Link
 	tcFilter                netlink.BpfFilter
 	tcClsActQdisc           netlink.Qdisc

--- a/selectors.go
+++ b/selectors.go
@@ -59,7 +59,7 @@ func (ps *ProbeSelector) RunValidator(manager *Manager) error {
 // EditProbeIdentificationPair - Changes all the selectors looking for the old ProbeIdentificationPair so that they
 // mow select the new one
 func (ps *ProbeSelector) EditProbeIdentificationPair(old ProbeIdentificationPair, new ProbeIdentificationPair) {
-	if ps.Matches(old) {
+	if ps.ProbeIdentificationPair == old {
 		ps.ProbeIdentificationPair = new
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Remove deprecated `EBPFSection` and make `ProbeIdentificationPair` comparable

### Motivation

Simpler code

### Additional Notes

API change by removing `Matches` and `EBPFDefinitionMatches`. Will bump to next minor (0.3) on next release.
