### PR TITLE
Use `CollectionOptions.MapReplacements` for map editing

### DIFF
--- a/examples/object_pinning/main.go
+++ b/examples/object_pinning/main.go
@@ -83,7 +83,7 @@ func run() error {
 	if kill {
 		log.Println("=> Stopping the program without cleanup, the pinned map should show up in /sys/fs/bpf/")
 		log.Println("=> Restart without --kill to load the pinned object from the bpf file system and properly remove them")
-		return m.Stop(manager.CleanInternalNotPinned | manager.CleanExternal)
+		return m.Stop(manager.CleanInternalNotPinned)
 	}
 	return m.Stop(manager.CleanAll)
 }

--- a/manager.go
+++ b/manager.go
@@ -950,7 +950,7 @@ func (m *Manager) stop(cleanup MapCleanupType) error {
 
 // NewMap - Create a new map using the provided parameters. The map is added to the list of maps managed by the manager.
 // Use a MapRoute to make this map available to the programs of the manager.
-func (m *Manager) NewMap(spec ebpf.MapSpec, options MapOptions) (*ebpf.Map, error) {
+func (m *Manager) NewMap(spec *ebpf.MapSpec, options MapOptions) (*ebpf.Map, error) {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
 	if m.collection == nil || m.state < initialized {
@@ -996,12 +996,12 @@ func (m *Manager) CloneMap(name string, newName string, options MapOptions) (*eb
 	// Duplicate spec and create a new map
 	spec := oldSpec.Copy()
 	spec.Name = newName
-	return m.NewMap(*spec, options)
+	return m.NewMap(spec, options)
 }
 
 // NewPerfRing - Creates a new perf ring and start listening for events.
 // Use a MapRoute to make this map available to the programs of the manager.
-func (m *Manager) NewPerfRing(spec ebpf.MapSpec, options MapOptions, perfMapOptions PerfMapOptions) (*ebpf.Map, error) {
+func (m *Manager) NewPerfRing(spec *ebpf.MapSpec, options MapOptions, perfMapOptions PerfMapOptions) (*ebpf.Map, error) {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
 	if m.state < initialized {
@@ -1052,12 +1052,12 @@ func (m *Manager) ClonePerfRing(name string, newName string, options MapOptions,
 	// Duplicate spec and create a new map
 	spec := oldSpec.Copy()
 	spec.Name = newName
-	return m.NewPerfRing(*spec, options, perfMapOptions)
+	return m.NewPerfRing(spec, options, perfMapOptions)
 }
 
 // NewRingBuffer - Creates a new ring buffer and start listening for events.
 // Use a MapRoute to make this map available to the programs of the manager.
-func (m *Manager) NewRingBuffer(spec ebpf.MapSpec, options MapOptions, ringBufferOptions RingBufferOptions) (*ebpf.Map, error) {
+func (m *Manager) NewRingBuffer(spec *ebpf.MapSpec, options MapOptions, ringBufferOptions RingBufferOptions) (*ebpf.Map, error) {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
 	if m.state < initialized {

--- a/manager.go
+++ b/manager.go
@@ -722,14 +722,6 @@ func (m *Manager) InitWithOptions(elf io.ReaderAt, options Options) error {
 		}
 	}
 
-	// newEditor program maps
-	if len(options.MapEditors) > 0 {
-		if err = m.editMaps(options.MapEditors); err != nil {
-			resetManager(m)
-			return err
-		}
-	}
-
 	// Patch instructions
 	if m.InstructionPatcher != nil {
 		if err := m.InstructionPatcher(m); err != nil {
@@ -970,7 +962,7 @@ func (m *Manager) NewMap(spec *ebpf.MapSpec, options MapOptions) (*ebpf.Map, err
 	}
 
 	// init map
-	if err := managerMap.init(m); err != nil {
+	if err := managerMap.init(); err != nil {
 		// Clean up
 		_ = managerMap.Close(CleanInternal)
 		return nil, err
@@ -1491,12 +1483,15 @@ func (m *Manager) matchBPFObjects() error {
 
 	// Match maps
 	for _, managerMap := range m.Maps {
-		if managerMap.externalMap {
-			continue
-		}
 		arr, ok := m.collection.Maps[managerMap.Name]
 		if !ok {
 			return fmt.Errorf("couldn't find map at maps/%s: %w", managerMap.Name, ErrUnknownSection)
+		}
+		// the `*ebpf.Map` reference may already be populated if pinned
+		if managerMap.array != nil {
+			// we don't need multiple references, so `Close` the new one
+			_ = arr.Close()
+			continue
 		}
 		managerMap.array = arr
 	}
@@ -1507,6 +1502,12 @@ func (m *Manager) matchBPFObjects() error {
 		if !ok {
 			return fmt.Errorf("couldn't find map at maps/%s: %w", perfMap.Name, ErrUnknownSection)
 		}
+		// the `*ebpf.Map` reference may already be populated if pinned
+		if perfMap.array != nil {
+			// we don't need multiple references, so `Close` the new one
+			_ = arr.Close()
+			continue
+		}
 		perfMap.array = arr
 	}
 
@@ -1515,6 +1516,12 @@ func (m *Manager) matchBPFObjects() error {
 		arr, ok := m.collection.Maps[ringBuffer.Name]
 		if !ok {
 			return fmt.Errorf("couldn't find map at maps/%s: %w", ringBuffer.Name, ErrUnknownSection)
+		}
+		// the `*ebpf.Map` reference may already be populated if pinned
+		if ringBuffer.array != nil {
+			// we don't need multiple references, so `Close` the new one
+			_ = arr.Close()
+			continue
 		}
 		ringBuffer.array = arr
 	}
@@ -1735,64 +1742,6 @@ func (m *Manager) rewriteMaps(program *ebpf.ProgramSpec, eBPFMaps map[string]*eb
 	return nil
 }
 
-// editMaps - RewriteMaps replaces all references to specific maps.
-func (m *Manager) editMaps(maps map[string]*ebpf.Map) error {
-	// Rewrite maps
-	for name, toRewrite := range maps {
-		// ignore deprecated usage
-		//nolint:staticcheck
-		//lint:ignore SA1019 using MapReplacements would require significant refactor
-		if err := m.collectionSpec.RewriteMaps(map[string]*ebpf.Map{name: toRewrite}); err != nil {
-			if m.options.MapEditorsIgnoreMissingMaps {
-				// make sure the map is removed from the collectionSpec
-				delete(m.collectionSpec.Maps, name)
-			} else {
-				return err
-			}
-		}
-	}
-
-	// The rewrite operation removed the original maps from the CollectionSpec and will therefore not appear in the
-	// Collection, make the mapping with the Manager.Maps now
-	found := false
-	for name, rwMap := range maps {
-		for _, managerMap := range m.Maps {
-			if managerMap.Name == name {
-				managerMap.array = rwMap
-				managerMap.externalMap = true
-				managerMap.editedMap = true
-				found = true
-			}
-		}
-		for _, perfRing := range m.PerfMaps {
-			if perfRing.Name == name {
-				perfRing.array = rwMap
-				perfRing.externalMap = true
-				perfRing.editedMap = true
-				found = true
-			}
-		}
-		for _, ringBuffer := range m.RingBuffers {
-			if ringBuffer.Name == name {
-				ringBuffer.array = rwMap
-				ringBuffer.externalMap = true
-				ringBuffer.editedMap = true
-				found = true
-			}
-		}
-		if !found && !m.options.MapEditorsIgnoreMissingMaps {
-			// Create a new entry
-			m.Maps = append(m.Maps, &Map{
-				array:       rwMap,
-				externalMap: true,
-				editedMap:   true,
-				Name:        name,
-			})
-		}
-	}
-	return nil
-}
-
 // editInnerOuterMapSpecs - Update the inner maps of the maps of maps in the collection spec
 func (m *Manager) editInnerOuterMapSpec(spec InnerOuterMapSpec) error {
 	// find the outer map
@@ -1820,8 +1769,18 @@ func (m *Manager) editInnerOuterMapSpec(spec InnerOuterMapSpec) error {
 // loadCollection - Load the eBPF maps and programs in the CollectionSpec. Programs and Maps are pinned when requested.
 func (m *Manager) loadCollection() error {
 	var err error
-	// Load collection
-	m.collection, err = ebpf.NewCollectionWithOptions(m.collectionSpec, m.options.VerifierOptions)
+
+	opts := m.options.VerifierOptions
+	// map references replaced this way will get a cloned reference to the *ebpf.Map upon collection load
+	opts.MapReplacements = maps.Clone(m.options.MapEditors)
+	for name := range opts.MapReplacements {
+		if _, ok := m.collectionSpec.Maps[name]; !ok && m.options.MapEditorsIgnoreMissingMaps {
+			// prevent error for missing map by removing the editor
+			delete(opts.MapReplacements, name)
+		}
+	}
+
+	m.collection, err = ebpf.NewCollectionWithOptions(m.collectionSpec, opts)
 	if err != nil {
 		var ve *ebpf.VerifierError
 		if errors.As(err, &ve) {
@@ -1838,7 +1797,7 @@ func (m *Manager) loadCollection() error {
 
 	// Initialize Maps
 	for _, managerMap := range m.Maps {
-		if err := managerMap.init(m); err != nil {
+		if err := managerMap.init(); err != nil {
 			return err
 		}
 	}
@@ -1937,12 +1896,8 @@ func (m *Manager) loadPinnedMap(managerMap *Map) error {
 		return fmt.Errorf("couldn't load map %s from %s: %w", managerMap.Name, managerMap.PinPath, err)
 	}
 
-	// Replace map in CollectionSpec
-	if err := m.editMaps(map[string]*ebpf.Map{managerMap.Name: pinnedMap}); err != nil {
-		return err
-	}
+	m.options.MapEditors[managerMap.Name] = pinnedMap
 	managerMap.array = pinnedMap
-	managerMap.externalMap = true
 	return nil
 }
 

--- a/map.go
+++ b/map.go
@@ -49,7 +49,7 @@ type Map struct {
 	array     *ebpf.Map
 	arraySpec *ebpf.MapSpec
 	state     state
-	stateLock sync.RWMutex
+	stateLock sync.Mutex
 
 	// externalMap - Indicates if the underlying eBPF map came from the current Manager or was loaded from an external
 	// source (=> pinned maps or rewritten maps)

--- a/map.go
+++ b/map.go
@@ -71,10 +71,10 @@ type Map struct {
 }
 
 // loadNewMap - Creates a new map instance, loads it and returns a pointer to the Map structure
-func loadNewMap(spec ebpf.MapSpec, options MapOptions) (*Map, error) {
+func loadNewMap(spec *ebpf.MapSpec, options MapOptions) (*Map, error) {
 	// Create new map
 	managerMap := Map{
-		arraySpec:  &spec,
+		arraySpec:  spec,
 		Name:       spec.Name,
 		Contents:   spec.Contents,
 		Freeze:     spec.Freeze,
@@ -83,7 +83,7 @@ func loadNewMap(spec ebpf.MapSpec, options MapOptions) (*Map, error) {
 
 	// Load map
 	var err error
-	if managerMap.array, err = ebpf.NewMap(&spec); err != nil {
+	if managerMap.array, err = ebpf.NewMap(spec); err != nil {
 		return nil, err
 	}
 

--- a/perf.go
+++ b/perf.go
@@ -179,8 +179,8 @@ func (m *PerfMap) Stop(cleanup MapCleanupType) error {
 
 // Pause - Pauses a perf ring buffer reader
 func (m *PerfMap) Pause() error {
-	m.stateLock.RLock()
-	defer m.stateLock.RUnlock()
+	m.stateLock.Lock()
+	defer m.stateLock.Unlock()
 	if m.state < running {
 		return ErrMapNotRunning
 	}
@@ -193,6 +193,8 @@ func (m *PerfMap) Pause() error {
 
 // Resume - Resumes a perf ring buffer reader
 func (m *PerfMap) Resume() error {
+	m.stateLock.Lock()
+	defer m.stateLock.Unlock()
 	if m.state < paused {
 		return ErrMapNotRunning
 	}

--- a/perf.go
+++ b/perf.go
@@ -50,16 +50,24 @@ type PerfMap struct {
 
 // loadNewPerfMap - Creates a new perf map instance, loads it and sets up the perf ring buffer reader
 func loadNewPerfMap(spec *ebpf.MapSpec, options MapOptions, perfOptions PerfMapOptions) (*PerfMap, error) {
-	// Create underlying map
-	innerMap, err := loadNewMap(spec, options)
-	if err != nil {
+	perfMap := PerfMap{
+		Map: Map{
+			arraySpec:  spec,
+			Name:       spec.Name,
+			MapOptions: options,
+		},
+		PerfMapOptions: perfOptions,
+	}
+
+	var err error
+	if perfMap.array, err = ebpf.NewMap(spec); err != nil {
 		return nil, err
 	}
 
-	// Create the new map
-	perfMap := PerfMap{
-		Map:            *innerMap, //nolint:govet
-		PerfMapOptions: perfOptions,
+	if perfMap.PinPath != "" {
+		if err = perfMap.array.Pin(perfMap.PinPath); err != nil {
+			return nil, fmt.Errorf("couldn't pin map %s at %s: %w", perfMap.Name, perfMap.PinPath, err)
+		}
 	}
 	return &perfMap, nil
 }
@@ -81,7 +89,7 @@ func (m *PerfMap) init(manager *Manager) error {
 	}
 
 	// Initialize the underlying map structure
-	if err := m.Map.init(manager); err != nil {
+	if err := m.Map.init(); err != nil {
 		return err
 	}
 	return nil

--- a/perf.go
+++ b/perf.go
@@ -49,7 +49,7 @@ type PerfMap struct {
 }
 
 // loadNewPerfMap - Creates a new perf map instance, loads it and sets up the perf ring buffer reader
-func loadNewPerfMap(spec ebpf.MapSpec, options MapOptions, perfOptions PerfMapOptions) (*PerfMap, error) {
+func loadNewPerfMap(spec *ebpf.MapSpec, options MapOptions, perfOptions PerfMapOptions) (*PerfMap, error) {
 	// Create underlying map
 	innerMap, err := loadNewMap(spec, options)
 	if err != nil {

--- a/probe.go
+++ b/probe.go
@@ -113,7 +113,6 @@ type Probe struct {
 	program                 *ebpf.Program
 	programSpec             *ebpf.ProgramSpec
 	perfEventFD             *fd
-	rawTracepointFD         *fd
 	state                   state
 	stateLock               sync.RWMutex
 	manualLoadNeeded        bool
@@ -845,7 +844,6 @@ func (p *Probe) reset() {
 	p.program = nil
 	p.programSpec = nil
 	p.perfEventFD = nil
-	p.rawTracepointFD = nil
 	p.state = reset
 	p.manualLoadNeeded = false
 	p.checkPin = false

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -32,7 +32,7 @@ type RingBuffer struct {
 }
 
 // loadNewRingBuffer - Creates a new ring buffer map instance, loads it and sets up the ring buffer reader
-func loadNewRingBuffer(spec ebpf.MapSpec, options MapOptions, ringBufferOptions RingBufferOptions) (*RingBuffer, error) {
+func loadNewRingBuffer(spec *ebpf.MapSpec, options MapOptions, ringBufferOptions RingBufferOptions) (*RingBuffer, error) {
 	// Create underlying map
 	innerMap, err := loadNewMap(spec, options)
 	if err != nil {

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -33,16 +33,24 @@ type RingBuffer struct {
 
 // loadNewRingBuffer - Creates a new ring buffer map instance, loads it and sets up the ring buffer reader
 func loadNewRingBuffer(spec *ebpf.MapSpec, options MapOptions, ringBufferOptions RingBufferOptions) (*RingBuffer, error) {
-	// Create underlying map
-	innerMap, err := loadNewMap(spec, options)
-	if err != nil {
+	ringBuffer := RingBuffer{
+		Map: Map{
+			arraySpec:  spec,
+			Name:       spec.Name,
+			MapOptions: options,
+		},
+		RingBufferOptions: ringBufferOptions,
+	}
+
+	var err error
+	if ringBuffer.array, err = ebpf.NewMap(spec); err != nil {
 		return nil, err
 	}
 
-	// Create the new map
-	ringBuffer := RingBuffer{
-		Map:               *innerMap, //nolint:govet
-		RingBufferOptions: ringBufferOptions,
+	if ringBuffer.PinPath != "" {
+		if err = ringBuffer.array.Pin(ringBuffer.PinPath); err != nil {
+			return nil, fmt.Errorf("couldn't pin map %s at %s: %w", ringBuffer.Name, ringBuffer.PinPath, err)
+		}
 	}
 	return &ringBuffer, nil
 }
@@ -61,7 +69,7 @@ func (rb *RingBuffer) init(manager *Manager) error {
 	}
 
 	// Initialize the underlying map structure
-	if err := rb.Map.init(manager); err != nil {
+	if err := rb.Map.init(); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
### What does this PR do?

Removes deprecated usage of `CollectionSpec.RewriteMaps` and uses `CollectionOptions.MapReplacements` instead.

`MapReplacements`  returns a cloned reference to the `*ebpf.Map` upon collection load. This allows us to get rid of the external/editing flags and tracking, because there is no danger of destructive operations upon `Close`. Pinned maps managed by the manager are detected and handled by the `array` field already being populated.

I split out the loading functions for maps/perfmap/ringbuffer to get rid of the mutex copy.

### Motivation

Remove deprecated usage of `CollectionSpec.RewriteMaps`.

### Additional Notes

This has a couple of API changes, so requires a version bump. 

### Describe how to test your changes

`map_rewrite_vs_map_router` example was tested and is still working.