### PR TITLE
Use unix.IoctlSetInt where appropriate

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -1014,11 +1014,17 @@ func (p *Probe) detachKprobe() error {
 }
 
 func (p *Probe) pauseKprobe() error {
-	return ioctlPerfEventDisable(p.perfEventFD)
+	if err := ioctlPerfEventDisable(p.perfEventFD); err != nil {
+		return fmt.Errorf("pause kprobe: %w", err)
+	}
+	return nil
 }
 
 func (p *Probe) resumeKprobe() error {
-	return ioctlPerfEventEnable(p.perfEventFD)
+	if err := ioctlPerfEventEnable(p.perfEventFD); err != nil {
+		return fmt.Errorf("resume kprobe: %w", err)
+	}
+	return nil
 }
 
 // attachTracepoint - Attaches the probe to its tracepoint
@@ -1054,11 +1060,17 @@ func (p *Probe) attachTracepoint() error {
 }
 
 func (p *Probe) pauseTracepoint() error {
-	return ioctlPerfEventDisable(p.perfEventFD)
+	if err := ioctlPerfEventDisable(p.perfEventFD); err != nil {
+		return fmt.Errorf("pause tracepoint: %w", err)
+	}
+	return nil
 }
 
 func (p *Probe) resumeTracepoint() error {
-	return ioctlPerfEventEnable(p.perfEventFD)
+	if err := ioctlPerfEventEnable(p.perfEventFD); err != nil {
+		return fmt.Errorf("resume tracepoint: %w", err)
+	}
+	return nil
 }
 
 // attachWithUprobeEvents attaches the uprobe using the uprobes_events ABI

--- a/syscalls.go
+++ b/syscalls.go
@@ -106,24 +106,15 @@ func perfEventOpenRaw(attr *unix.PerfEventAttr, pid int, cpu int, groupFd int, f
 }
 
 func ioctlPerfEventSetBPF(perfEventOpenFD *fd, progFD int) error {
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_SET_BPF, uintptr(progFD)); err != 0 {
-		return fmt.Errorf("error attaching bpf program to perf event: %w", err)
-	}
-	return nil
+	return unix.IoctlSetInt(int(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_SET_BPF, progFD)
 }
 
 func ioctlPerfEventEnable(perfEventOpenFD *fd) error {
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_ENABLE, 0); err != 0 {
-		return fmt.Errorf("error enabling perf event: %w", err)
-	}
-	return nil
+	return unix.IoctlSetInt(int(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_ENABLE, 0)
 }
 
 func ioctlPerfEventDisable(perfEventOpenFD *fd) error {
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_DISABLE, 0); err != 0 {
-		return fmt.Errorf("error disabling perf event: %w", err)
-	}
-	return nil
+	return unix.IoctlSetInt(int(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_DISABLE, 0)
 }
 
 type bpfProgAttachAttr struct {


### PR DESCRIPTION
### What does this PR do?

Use `unix.IoctlSetInt` where appropriate

### Motivation

better type safety
