### PR TITLE
Use link for cgroup attach/detach

### DIFF
--- a/cgroup.go
+++ b/cgroup.go
@@ -1,0 +1,21 @@
+package manager
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/link"
+)
+
+// attachCGroup - Attaches the probe to a cgroup hook point
+func (p *Probe) attachCGroup() error {
+	var err error
+	p.progLink, err = link.AttachCgroup(link.CgroupOptions{
+		Path:    p.CGroupPath,
+		Attach:  p.programSpec.AttachType,
+		Program: p.program,
+	})
+	if err != nil {
+		return fmt.Errorf("cgroup link %s: %w", p.CGroupPath, err)
+	}
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Use link for cgroup attach/detach

### Motivation

Supports bpf links where available. Reduces code footprint of this library.
