### PR TITLE
Use link for tracing programs

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -1,0 +1,19 @@
+package manager
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/link"
+)
+
+func (p *Probe) attachTracing() error {
+	var err error
+	p.progLink, err = link.AttachTracing(link.TracingOptions{
+		Program:    p.program,
+		AttachType: p.programSpec.AttachType,
+	})
+	if err != nil {
+		return fmt.Errorf("link tracing: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Use link for tracing programs

### Motivation

Supports bpf links where available. Reduces code footprint of this library.