### PR TITLE
ensure we do not read the whole kallsyms file in memory

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -153,6 +153,8 @@ func getSyscallFnNameWithKallsyms(name string, kallsymsContent io.Reader, arch s
 	// check for '__' prefixed functions, like '__sys_open'
 	prefixed := regexp.MustCompile(`\b__[Ss]y[sS]_` + name + `\b`)
 
+	patterns := []*regexp.Regexp{newSyscall, oldSyscall, prefixed}
+
 	scanner := bufio.NewScanner(kallsymsContent)
 	scanner.Split(bufio.ScanLines)
 
@@ -163,7 +165,7 @@ func getSyscallFnNameWithKallsyms(name string, kallsymsContent io.Reader, arch s
 			continue
 		}
 
-		for _, pattern := range []*regexp.Regexp{newSyscall, oldSyscall, prefixed} {
+		for _, pattern := range patterns {
 			if res := pattern.FindString(line); res != "" {
 				return res, nil
 			}

--- a/utils.go
+++ b/utils.go
@@ -130,18 +130,19 @@ func getSyscallName(name string, symFile string) (string, error) {
 	}
 	defer syms.Close()
 
-	return getSyscallFnNameWithKallsyms(name, syms)
+	return getSyscallFnNameWithKallsyms(name, syms, "")
 }
 
-func getSyscallFnNameWithKallsyms(name string, kallsymsContent io.Reader) (string, error) {
-	var arch string
-	switch runtime.GOARCH {
-	case "386":
-		arch = "ia32"
-	case "arm64":
-		arch = "arm64"
-	default:
-		arch = "x64"
+func getSyscallFnNameWithKallsyms(name string, kallsymsContent io.Reader, arch string) (string, error) {
+	if arch == "" {
+		switch runtime.GOARCH {
+		case "386":
+			arch = "ia32"
+		case "arm64":
+			arch = "arm64"
+		default:
+			arch = "x64"
+		}
 	}
 
 	// We should search for new syscall function like "__x64__sys_open"

--- a/utils.go
+++ b/utils.go
@@ -153,6 +153,8 @@ func getSyscallFnNameWithKallsyms(name string, kallsymsContent io.Reader, arch s
 	// check for '__' prefixed functions, like '__sys_open'
 	prefixed := regexp.MustCompile(`\b__[Ss]y[sS]_` + name + `\b`)
 
+	// the order of patterns is important
+	// we first want to look for the new syscall format, then the old format, then the prefixed format
 	patterns := []struct {
 		pattern *regexp.Regexp
 		result  string

--- a/utils_test.go
+++ b/utils_test.go
@@ -67,7 +67,7 @@ func TestGetSyscallFnNameWithKallsyms(t *testing.T) {
 0000000000000000 t arch_local_irq_save
 	`
 
-	res, err := getSyscallFnNameWithKallsyms("open", bytes.NewBuffer([]byte(kallsymsContent)))
+	res, err := getSyscallFnNameWithKallsyms("open", bytes.NewBuffer([]byte(kallsymsContent)), "arm64")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -31,3 +31,48 @@ func TestGenerateEventName(t *testing.T) {
 		t.Errorf("Test should failed as event name length is too big for the kernel and free space for function Name is < %d", minFunctionNameLen)
 	}
 }
+
+func TestGetSyscallFnNameWithKallsyms(t *testing.T) {
+	kallsymsContent := `
+0000000000000000 T do_fchownat
+0000000000000000 T __arm64_sys_fchownat
+0000000000000000 T __arm64_sys_chown
+0000000000000000 T __arm64_sys_lchown
+0000000000000000 T vfs_fchown
+0000000000000000 T ksys_fchown
+0000000000000000 T __arm64_sys_fchown
+0000000000000000 T vfs_open
+0000000000000000 T build_open_how
+0000000000000000 T build_open_flags
+0000000000000000 t do_sys_openat2
+0000000000000000 t __do_sys_openat2
+0000000000000000 T __arm64_sys_openat2
+0000000000000000 T __arm64_sys_creat
+0000000000000000 T __arm64_compat_sys_open
+0000000000000000 T __arm64_compat_sys_openat
+0000000000000000 T __arm64_sys_open
+0000000000000000 T __arm64_sys_openat
+0000000000000000 T file_open_name
+0000000000000000 T do_sys_open
+0000000000000000 T vfs_setpos
+0000000000000000 T generic_file_llseek_size
+0000000000000000 T generic_file_llseek
+0000000000000000 T fixed_size_llseek
+0000000000000000 T no_seek_end_llseek
+0000000000000000 T no_seek_end_llseek_size
+0000000000000000 T noop_llseek
+0000000000000000 T vfs_llseek
+0000000000000000 T default_llseek
+0000000000000000 t arch_local_irq_save
+	`
+
+	res, err := getSyscallFnNameWithKallsyms("open", kallsymsContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "__arm64_sys_open"
+	if res != expected {
+		t.Errorf("expected %s, got %s", expected, res)
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -66,7 +67,7 @@ func TestGetSyscallFnNameWithKallsyms(t *testing.T) {
 0000000000000000 t arch_local_irq_save
 	`
 
-	res, err := getSyscallFnNameWithKallsyms("open", kallsymsContent)
+	res, err := getSyscallFnNameWithKallsyms("open", bytes.NewBuffer([]byte(kallsymsContent)))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### What does this PR do?

The function `GetSyscallFnName` currently needs to read the whole kallsyms in memory. This PR changes this to just stream the file line by line.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
