### PR TITLE
Use reference to ensure slice entry is mutated

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -174,7 +174,8 @@ func getSyscallFnNameWithKallsyms(name string, kallsymsContent io.Reader, arch s
 			continue
 		}
 
-		for i, p := range patterns {
+		for i := range patterns {
+			p := &patterns[i]
 			// if we already found a match for this pattern we continue
 			if p.result != "" {
 				continue

--- a/utils_test.go
+++ b/utils_test.go
@@ -84,6 +84,14 @@ func TestGetSyscallFnNameWithKallsyms(t *testing.T) {
 	`,
 			expected: "__arm64_sys_connect",
 		},
+		{
+			fnName: "open",
+			kallsymsContent: `
+0000000000000000 T __SyS_open
+0000000000000000 T __sys_open
+	`,
+			expected: "__SyS_open",
+		},
 	}
 
 	for i, testEntry := range entries {


### PR DESCRIPTION
### What does this PR do?

Uses a pointer to the slice entry, so it will be mutated, rather than a copy.

### Motivation

Fix #145 