### PR TITLE
memory improvements for `FindFilterFunction`

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1626,8 +1626,6 @@ func (m *Manager) UpdateActivatedProbes(selectors []ProbesSelector) error {
 		return fmt.Errorf("probes activation validation failed: %w", validationErrs)
 	}
 
-	clearAvailableFilterFunctionsCache()
-
 	return nil
 }
 
@@ -1826,8 +1824,6 @@ func (m *Manager) loadCollection() error {
 			return err
 		}
 	}
-
-	clearAvailableFilterFunctionsCache()
 
 	return nil
 }

--- a/manager.go
+++ b/manager.go
@@ -1824,7 +1824,6 @@ func (m *Manager) loadCollection() error {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/manager.go
+++ b/manager.go
@@ -1626,6 +1626,8 @@ func (m *Manager) UpdateActivatedProbes(selectors []ProbesSelector) error {
 		return fmt.Errorf("probes activation validation failed: %w", validationErrs)
 	}
 
+	clearAvailableFilterFunctionsCache()
+
 	return nil
 }
 
@@ -1824,6 +1826,9 @@ func (m *Manager) loadCollection() error {
 			return err
 		}
 	}
+
+	clearAvailableFilterFunctionsCache()
+
 	return nil
 }
 

--- a/tracefs/tracefs.go
+++ b/tracefs/tracefs.go
@@ -70,11 +70,7 @@ func ReadFile(relname string) ([]byte, error) {
 
 // Open opens the relative path provided (similar to os.Open), using the detected root of tracefs or debugfs
 func Open(relname string) (*os.File, error) {
-	root, err := getRoot()
-	if err != nil {
-		return nil, err
-	}
-	return os.Open(filepath.Join(root, relname))
+	return OpenFile(relname, os.O_RDONLY, 0)
 }
 
 // OpenFile opens the relative path provided (similar to os.OpenFile), using the detected root of tracefs or debugfs

--- a/tracefs/tracefs.go
+++ b/tracefs/tracefs.go
@@ -68,7 +68,16 @@ func ReadFile(relname string) ([]byte, error) {
 	return os.ReadFile(filepath.Join(root, relname))
 }
 
-// OpenFile opens the relative path provided, using the detected root of tracefs or debugfs
+// Open opens the relative path provided (similar to os.Open), using the detected root of tracefs or debugfs
+func Open(relname string) (*os.File, error) {
+	root, err := getRoot()
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(filepath.Join(root, relname))
+}
+
+// OpenFile opens the relative path provided (similar to os.OpenFile), using the detected root of tracefs or debugfs
 func OpenFile(relname string, flag int, perm os.FileMode) (*os.File, error) {
 	root, err := getRoot()
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -44,7 +44,8 @@ const (
 // availableFilterFunctions - cache of the list of available kernel functions.
 var availableFilterFunctions struct {
 	sync.Mutex
-	cache []string
+	cache     []string
+	cacheSize int
 }
 
 func clearAvailableFilterFunctionsCache() {
@@ -71,6 +72,10 @@ func FindFilterFunction(funcName string) (string, error) {
 		}
 		defer funcsReader.Close()
 
+		if availableFilterFunctions.cacheSize != 0 {
+			availableFilterFunctions.cache = make([]string, 0, availableFilterFunctions.cacheSize)
+		}
+
 		funcs := bufio.NewScanner(funcsReader)
 		funcs.Split(bufio.ScanLines)
 
@@ -83,6 +88,7 @@ func FindFilterFunction(funcName string) (string, error) {
 		if err := funcs.Err(); err != nil {
 			return "", err
 		}
+		availableFilterFunctions.cacheSize = len(availableFilterFunctions.cache)
 	}
 
 	// Match function name

--- a/utils.go
+++ b/utils.go
@@ -59,15 +59,15 @@ func FindFilterFunction(funcName string) (string, error) {
 
 	var potentialMatches []string
 	for funcs.Scan() {
-		name := funcs.Text()
-		name, _, _ = strings.Cut(name, " ")
-		name, _, _ = strings.Cut(name, "\t")
+		name := funcs.Bytes()
+		name, _, _ = bytes.Cut(name, []byte(" "))
+		name, _, _ = bytes.Cut(name, []byte("\t"))
 
-		if searchedName.MatchString(name) {
-			potentialMatches = append(potentialMatches, name)
+		if string(name) == funcName {
+			return funcName, nil
 		}
-		if name == funcName {
-			return name, nil
+		if searchedName.Match(name) {
+			potentialMatches = append(potentialMatches, string(name))
 		}
 	}
 	if err := funcs.Err(); err != nil {

--- a/utils.go
+++ b/utils.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -72,13 +71,10 @@ func FindFilterFunction(funcName string) (string, error) {
 		}
 		availableFilterFunctions.cache = strings.Split(string(funcs), "\n")
 		for i, name := range availableFilterFunctions.cache {
-			splittedName := strings.Split(name, " ")
-			name = splittedName[0]
-			splittedName = strings.Split(name, "\t")
-			name = splittedName[0]
+			name, _, _ = strings.Cut(name, " ")
+			name, _, _ = strings.Cut(name, "\t")
 			availableFilterFunctions.cache[i] = name
 		}
-		sort.Strings(availableFilterFunctions.cache)
 	}
 
 	// Match function name

--- a/utils.go
+++ b/utils.go
@@ -42,7 +42,7 @@ const (
 	maxBPFClassifierNameLen = 256
 )
 
-// availableFilterFunctionsCacheSize
+// availableFilterFunctionsCacheSize - caches the number of lines in available_filter_functions file
 var availableFilterFunctionsCacheSize atomic.Int64
 
 func FindFilterFunction(funcName string) (string, error) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 	"testing"
 )
 
@@ -105,5 +106,23 @@ func TestGetSyscallFnNameWithKallsyms(t *testing.T) {
 				t.Errorf("expected %s, got %s", testEntry.expected, res)
 			}
 		})
+	}
+}
+
+func BenchmarkFindFilterFunction(b *testing.B) {
+	var needle string
+	switch runtime.GOARCH {
+	case "arm64":
+		needle = "__arm64_sys_open"
+	default:
+		needle = "__x64_sys_open"
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, err := FindFilterFunction(needle)
+		if err != nil {
+			b.Error(err)
+		}
+		clearAvailableFilterFunctionsCache()
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -123,6 +123,5 @@ func BenchmarkFindFilterFunction(b *testing.B) {
 		if err != nil {
 			b.Error(err)
 		}
-		clearAvailableFilterFunctionsCache()
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR improves the memory profile of the un-cached `FindFilterFunction`:
- removing useless splits and sort
- switching to line-by-line reading of the file (allowing us to only keep a copy of the interesting string and not the whole buffer at once)
and removes the cache completely, because it caches a lot of entries even though the usage of it is pretty low (around 60000 entries, when the system probe only uses this for 2 hooks). Removing the cache is not an issue in itself because `available_filter_functions` is not a regular file, so no real IO there.

Here is a profile showing the gain https://ddstaging.datadoghq.com/profiling/comparison?query=service%3Asystem-probe%20kube_cluster_name%3Astingchameleon%20&compare_end_A=1694707013705&compare_start_A=1694703413705&compareValuesMode=absolute&my_code=disabled&profile_type=heap-live-size&viz=flame_graph&start=1694707010394&end=1694710610394&paused=false

Benchmark:
```sh
>> go test -exec sudo -run=^# -bench BenchmarkFindFilterFunction -benchmem -benchtime 10s
goos: linux
goarch: arm64

# before
BenchmarkFindFilterFunction-4   	     100	 109692621 ns/op	11100796 B/op	  123021 allocs/op
# after
BenchmarkFindFilterFunction-4   	    1552	   7721956 ns/op	    7872 B/op	      28 allocs/op
```


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
