### PR TITLE
cleanup ProgramSpec after init

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -565,7 +565,7 @@ func (m *Manager) InitWithOptions(elf io.ReaderAt, options Options) error {
 	// Load eBPF program with the provided verifier options
 	if err = m.loadCollection(); err != nil {
 		if m.collection != nil {
-			_ = m.collection.Close
+			m.collection.Close()
 		}
 		resetManager(m)
 		return err

--- a/probe.go
+++ b/probe.go
@@ -291,6 +291,7 @@ func (p *Probe) Benchmark(in []byte, repeat int, reset func()) (uint32, time.Dur
 // initWithOptions - Initializes a probe with options
 func (p *Probe) initWithOptions(manager *Manager, manualLoadNeeded bool, checkPin bool) error {
 	if !p.Enabled {
+		p.cleanupProgramSpec()
 		return nil
 	}
 
@@ -304,6 +305,7 @@ func (p *Probe) initWithOptions(manager *Manager, manualLoadNeeded bool, checkPi
 // init - Initialize a probe
 func (p *Probe) init(manager *Manager) error {
 	if !p.Enabled {
+		p.cleanupProgramSpec()
 		return nil
 	}
 	p.stateLock.Lock()
@@ -461,6 +463,7 @@ func (p *Probe) internalInit(manager *Manager) error {
 
 	// update probe state
 	p.state = initialized
+	p.cleanupProgramSpec()
 	return nil
 }
 
@@ -545,9 +548,6 @@ func (p *Probe) attach() error {
 	// update probe state
 	p.state = running
 	p.attachRetryAttempt = p.getRetryAttemptCount()
-
-	// cleanup ProgramSpec to free up some memory
-	p.cleanupProgramSpec()
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

- Calls `Probe.cleanupProgramSpec()` after init, because the program has already been loaded at that point and the instructions are no longer needed.
- Calls `Probe.cleanupProgramSpec()` for `Probe` objects that are not `Enabled`.

### Motivation

Leftover instructions in `ebpf.ProgramSpec` using heap memory. Specifically for tail calls and other Probes that are declared, but not `Enabled` or `Activated`.

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-250
