### PR TITLE
Fix `CleanupNetworkNamespace` not properly detaching eBPF programs

### DIFF
--- a/netlink.go
+++ b/netlink.go
@@ -122,11 +122,11 @@ func (m *Manager) CleanupNetworkNamespace(nsID uint32) error {
 			continue
 		}
 
-		// disable probe
-		probe.Enabled = false
-
 		// stop the probe
 		errs = append(errs, probe.Stop())
+
+		// disable probe
+		probe.Enabled = false
 
 		// append probe to delete (biggest indexes first)
 		toDelete = append([]int{i}, toDelete...)


### PR DESCRIPTION

### What does this PR do?

Calls `Probe.Stop()` before setting the `Probe.Enabled` flag to false. 

### Motivation

This fixes the `CleanupNetworkNamespace` function which was resetting tc Probes instead of detaching them from the corresponding interface. This caused eBPF programs to never be detached from interfaces even after the manager was closed.