### PR TITLE
Fix race between `probe.Stop()` and `probe.ID()`

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -257,7 +257,12 @@ func (p *Probe) GetLastError() error {
 
 // ID returns the system-wide unique ID for this program
 func (p *Probe) ID() uint32 {
-	return uint32(p.systemWideID)
+	p.stateLock.RLock()
+	defer p.stateLock.RUnlock()
+	if p.state >= initialized {
+		return uint32(p.systemWideID)
+	}
+	return 0
 }
 
 // IsRunning - Returns true if the probe was successfully initialized, started and is currently running or paused.

--- a/probe.go
+++ b/probe.go
@@ -259,10 +259,7 @@ func (p *Probe) GetLastError() error {
 func (p *Probe) ID() uint32 {
 	p.stateLock.RLock()
 	defer p.stateLock.RUnlock()
-	if p.state >= initialized {
-		return uint32(p.systemWideID)
-	}
-	return 0
+	return uint32(p.systemWideID)
 }
 
 // IsRunning - Returns true if the probe was successfully initialized, started and is currently running or paused.


### PR DESCRIPTION
### What does this PR do?

This PR fixes a data race on `systemWideID` triggering when `Probe.Stop()` and `Probe.ID()` are called concurrently.
