### PR TITLE
optimize "manager wide" constant rewriting

### DIFF
--- a/constant_editor.go
+++ b/constant_editor.go
@@ -74,7 +74,7 @@ func (m *Manager) editConstants() error {
 
 	// Apply to all programs if no section was provided
 	for section, prog := range m.collectionSpec.Programs {
-		edit := newEditor(&prog.Instructions)
+		var edit *editor
 		for _, constantEditor := range m.options.ConstantEditors {
 			if constantEditor.BTFGlobalConstant {
 				continue
@@ -82,6 +82,10 @@ func (m *Manager) editConstants() error {
 
 			if len(constantEditor.ProbeIdentificationPairs) != 0 {
 				continue
+			}
+
+			if edit == nil {
+				edit = newEditor(&prog.Instructions)
 			}
 
 			if err := m.editConstantWithEditor(edit, constantEditor); err != nil {


### PR DESCRIPTION
### What does this PR do?

Most constant editors are actually "manager wide", meaning that they target all programs under a given manager. Currently when rewriting this kind of constants we iterator over all constant entries, then for each program we create an editor that does the edition. The issue is that creating an editor iterates over all instructions searching for "references", and thus we do a lot of repetitive work (and it's starting to show up in profiles, especially in test profiles were we continuously restart the manager).

To improve this situation this PR reverses the order of iteration for "manager wide" constants by creating an editor only once per program.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
