### PR TITLE
add missing lock in `netlinkSocketCache.remove`

### DIFF
--- a/netlink.go
+++ b/netlink.go
@@ -88,6 +88,9 @@ func (nsc *netlinkSocketCache) cleanup() {
 }
 
 func (nsc *netlinkSocketCache) remove(nsID uint32) {
+	nsc.Lock()
+	defer nsc.Unlock()
+
 	s, ok := nsc.cache[nsID]
 	if ok {
 		delete(nsc.cache, nsID)


### PR DESCRIPTION
### What does this PR do?

This PR adds the missing lock in `netlinkSocketCache.remove`. This function is not exported and only called from `manager.CleanupNetworkNamespace` which means it's never called with the lock already taken (ensuring this PR is not introducing any deadlock).

Agent PR to test this PR: https://github.com/DataDog/datadog-agent/pull/21053

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
