### PR TITLE
Add perf telemetry collection

### DIFF
--- a/perfmap.go
+++ b/perfmap.go
@@ -77,16 +77,6 @@ func loadNewPerfMap(spec *ebpf.MapSpec, options MapOptions, perfOptions PerfMapO
 		}
 	}
 
-	if perfOptions.TelemetryEnabled {
-		nCPU := perfMap.array.MaxEntries()
-		perfMap.usageTelemetry = make([]*atomic.Uint64, nCPU)
-		perfMap.lostTelemetry = make([]*atomic.Uint64, nCPU)
-		for cpu := range perfMap.usageTelemetry {
-			perfMap.usageTelemetry[cpu] = &atomic.Uint64{}
-			perfMap.lostTelemetry[cpu] = &atomic.Uint64{}
-		}
-	}
-
 	return &perfMap, nil
 }
 
@@ -104,6 +94,16 @@ func (m *PerfMap) init(manager *Manager) error {
 	}
 	if m.Watermark == 0 {
 		m.Watermark = manager.options.DefaultWatermark
+	}
+
+	if m.TelemetryEnabled {
+		nCPU := m.array.MaxEntries()
+		m.usageTelemetry = make([]*atomic.Uint64, nCPU)
+		m.lostTelemetry = make([]*atomic.Uint64, nCPU)
+		for cpu := range m.usageTelemetry {
+			m.usageTelemetry[cpu] = &atomic.Uint64{}
+			m.lostTelemetry[cpu] = &atomic.Uint64{}
+		}
 	}
 
 	// Initialize the underlying map structure

--- a/perfmap.go
+++ b/perfmap.go
@@ -162,6 +162,8 @@ func (m *PerfMap) Start() error {
 			if record.LostSamples > 0 {
 				if m.lostTelemetry != nil && record.CPU < len(m.lostTelemetry) {
 					m.lostTelemetry[record.CPU].Add(record.LostSamples)
+					// force usage to max because a sample was lost
+					updateMaxTelemetry(m.usageTelemetry[record.CPU], uint64(m.bufferSize))
 				}
 				if m.LostHandler != nil {
 					m.LostHandler(record.CPU, record.LostSamples, m, m.manager)

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -66,9 +66,6 @@ func loadNewRingBuffer(spec *ebpf.MapSpec, options MapOptions, ringBufferOptions
 		}
 	}
 
-	if ringBufferOptions.TelemetryEnabled {
-		ringBuffer.usageTelemetry = &atomic.Uint64{}
-	}
 	return &ringBuffer, nil
 }
 
@@ -83,6 +80,10 @@ func (rb *RingBuffer) init(manager *Manager) error {
 	// Set default values if not already set
 	if rb.RingBufferSize == 0 {
 		rb.RingBufferSize = manager.options.DefaultRingBufferSize
+	}
+
+	if rb.TelemetryEnabled {
+		rb.usageTelemetry = &atomic.Uint64{}
 	}
 
 	// Initialize the underlying map structure


### PR DESCRIPTION
### What does this PR do?

Adds optional collection of perf (perf buffer and ring buffer) telemetry

### Motivation

Simplifies consumption of the telemetry values from the users of ebpf-manager.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
