### PR TITLE
fix tracefs uprobe detach leak

### DIFF
--- a/tracefs.go
+++ b/tracefs.go
@@ -175,7 +175,7 @@ func getKernelGeneratedEventName(probeType, funcName string) string {
 }
 
 func unregisterTraceFSEvent(eventsFile string, name string) error {
-	f, err := tracefs.OpenFile(eventsFile, os.O_APPEND|os.O_WRONLY, 0)
+	f, err := tracefs.OpenFile(eventsFile, os.O_APPEND|os.O_WRONLY, 0666)
 	if err != nil {
 		return fmt.Errorf("open %s: %w", eventsFile, err)
 	}


### PR DESCRIPTION
### What does this PR do?

Fixes uprobes attached via tracefs using the wrong file upon detach.

### Motivation

If uprobes were attached via tracefs, then upon detach they would try to use the `kprobe_events` file. This was because the `GetUProbeType()` function would assign to `p.kprobeType`, which was later used as an indication of if it was a kprobe or uprobe.
