### PR TITLE
add program bypass support

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -660,7 +660,7 @@ func (m *Manager) setupBypass() (*Map, error) {
 	const stackOffset = -8
 	// place a limit on how far we will inject from the start of a program
 	// otherwise we aren't sure what register we need to save/restore, and it could inflate the number of instructions.
-	const maxInstructionOffsetFromProgramStart = 5
+	const maxInstructionOffsetFromProgramStart = 1
 	// setup bypass constants for all programs
 	m.bypassIndexes = make(map[string]uint32, len(m.collectionSpec.Programs))
 	for name, p := range m.collectionSpec.Programs {

--- a/manager.go
+++ b/manager.go
@@ -673,6 +673,9 @@ func (m *Manager) setupBypass() (*Map, error) {
 			if i > maxInstructionOffsetFromProgramStart {
 				return nil, fmt.Errorf("unable to inject bypass instructions into program %s: bypass reference occurs too late in program", name)
 			}
+			if i > 0 && p.Instructions[i-1].Src != asm.R1 {
+				return nil, fmt.Errorf("unable to inject bypass instructions into program %s: register other than r1 used before injection point", name)
+			}
 
 			m.bypassIndexes[name] = m.maxBypassIndex
 			newInsns := append([]asm.Instruction{

--- a/perf_event.go
+++ b/perf_event.go
@@ -85,14 +85,6 @@ func (pe *perfEventLink) Close() error {
 	return pe.fd.Close()
 }
 
-func (pe *perfEventLink) Pause() error {
-	return ioctlPerfEventDisable(pe.fd)
-}
-
-func (pe *perfEventLink) Resume() error {
-	return ioctlPerfEventEnable(pe.fd)
-}
-
 func attachPerfEvent(pe *perfEventLink, prog *ebpf.Program) error {
 	if err := ioctlPerfEventSetBPF(pe.fd, prog.FD()); err != nil {
 		return fmt.Errorf("set perf event bpf: %w", err)
@@ -210,8 +202,4 @@ func ioctlPerfEventSetBPF(perfEventOpenFD *fd, progFD int) error {
 
 func ioctlPerfEventEnable(perfEventOpenFD *fd) error {
 	return unix.IoctlSetInt(int(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_ENABLE, 0)
-}
-
-func ioctlPerfEventDisable(perfEventOpenFD *fd) error {
-	return unix.IoctlSetInt(int(perfEventOpenFD.raw), unix.PERF_EVENT_IOC_DISABLE, 0)
 }

--- a/utils.go
+++ b/utils.go
@@ -51,3 +51,12 @@ func cleanupProgramSpec(spec *ebpf.ProgramSpec) {
 		spec.Instructions = nil
 	}
 }
+
+// create slice of length n and fill with fillVal
+func makeAndSet[E any](n int, fillVal E) []E {
+	s := make([]E, n)
+	for i := range s {
+		s[i] = fillVal
+	}
+	return s
+}


### PR DESCRIPTION
### What does this PR do?

Adds `BypassEnabled` config option for the manager, which adds on/off user control of bypassing (early return) eBPF programs. It accomplishes this by injecting some instructions at the beginning of opted-in programs. Opt-in is accomplished by loading a named reference constant.

The actual bypass is controlled via a per-manager array map (per-cpu if supported). Each index corresponds to a unique ebpf program.

### Motivation

The previous `Pause/Resume` functions did not operate as expected.

### Additional Notes

### Describe how to test your changes

Testing in the datadog-agent by the existing usage of protocol classification tests.
