### PR TITLE
remove unused RingBufferSize

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -84,10 +84,6 @@ type Options struct {
 	// on the system. See PerfMap.PerfRingBuffer for more.
 	DefaultPerfRingBufferSize int
 
-	// RingBufferSize - Manager-level default value for the ring buffers. Defaults to the size of 1 page
-	// on the system.
-	DefaultRingBufferSize int
-
 	// Watermark - Manager-level default value for the watermarks of the perf ring buffers.
 	// See PerfMap.Watermark for more.
 	DefaultWatermark int
@@ -450,9 +446,6 @@ func (m *Manager) InitWithOptions(elf io.ReaderAt, options Options) error {
 	m.netlinkSocketCache = newNetlinkSocketCache()
 	if m.options.DefaultPerfRingBufferSize == 0 {
 		m.options.DefaultPerfRingBufferSize = os.Getpagesize()
-	}
-	if m.options.DefaultRingBufferSize == 0 {
-		m.options.DefaultRingBufferSize = os.Getpagesize() * 16
 	}
 
 	// perform a quick sanity check on the provided probes and maps

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -11,9 +11,6 @@ import (
 )
 
 type RingBufferOptions struct {
-	// RingBufferSize - Size in bytes of the ring buffer. Defaults to the manager value if not set.
-	RingBufferSize int
-
 	// ErrChan - Reader error channel
 	ErrChan chan error
 
@@ -75,11 +72,6 @@ func (rb *RingBuffer) init(manager *Manager) error {
 
 	if rb.DataHandler == nil && rb.RecordHandler == nil {
 		return fmt.Errorf("no DataHandler/RecordHandler set for %s", rb.Name)
-	}
-
-	// Set default values if not already set
-	if rb.RingBufferSize == 0 {
-		rb.RingBufferSize = manager.options.DefaultRingBufferSize
 	}
 
 	if rb.TelemetryEnabled {


### PR DESCRIPTION
### What does this PR do?

remove unused `RingBufferSize` and `DefaultRingBufferSize`

### Motivation

It had no effect. Ring buffers are sized with `MaxEntries`.

### Additional Notes

### Describe how to test your changes
