### PR TITLE
allow user to manually load elf before Init

### DIFF
--- a/err.go
+++ b/err.go
@@ -5,6 +5,8 @@ import "errors"
 var (
 	ErrManagerNotInitialized    = errors.New("the manager must be initialized first")
 	ErrManagerNotStarted        = errors.New("the manager must be started first")
+	ErrManagerNotELFLoaded      = errors.New("the manager has not loaded the ELF data")
+	ErrManagerELFLoaded         = errors.New("the manager has already loaded the ELF data")
 	ErrManagerRunning           = errors.New("the manager is already running")
 	ErrUnknownSection           = errors.New("unknown section")
 	ErrUnknownSectionOrFuncName = errors.New("unknown section or eBPF function name")

--- a/state.go
+++ b/state.go
@@ -4,6 +4,7 @@ type state uint
 
 const (
 	reset state = iota
+	elfLoaded
 	initialized
 	stopped
 	paused


### PR DESCRIPTION
### What does this PR do?

allow user to (optionally) manually load elf before Init

### Motivation

We sometimes need information from the collectionspec to craft the correct options before the manager is initialized. One example is upgrading map types.

### Additional Notes


### Describe how to test your changes

