### PR TITLE
add `CloneProgramWithSpecEditor` allowing to edit the program spec during program copy

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1169,16 +1169,18 @@ func (m *Manager) DetachHook(id ProbeIdentificationPair) error {
 	return nil
 }
 
-func (m *Manager) CloneProgram(UID string, newProbe *Probe, constantsEditors []ConstantEditor, mapEditors map[string]*ebpf.Map) error {
-	return m.CloneProgramWithSpecEditor(UID, newProbe, constantsEditors, mapEditors, nil)
-}
-
-// CloneProgramWithSpecEditor - Create a clone of a program, load it in the kernel and attach it to its hook point. Since the eBPF
+// CloneProgram - Create a clone of a program, load it in the kernel and attach it to its hook point. Since the eBPF
 // program instructions are copied before the program is loaded, you can edit them with a ConstantEditor, or remap
 // the eBPF maps as you like. This is particularly useful to work around the absence of Array of Maps and Hash of Maps:
 // first create the new maps you need, then clone the program you're interested in and rewrite it with the new maps,
 // using a MapEditor. The original program is selected using the provided UID and the section provided in the new probe.
 // Note that the BTF based constant edition will not work with this method.
+func (m *Manager) CloneProgram(UID string, newProbe *Probe, constantsEditors []ConstantEditor, mapEditors map[string]*ebpf.Map) error {
+	return m.CloneProgramWithSpecEditor(UID, newProbe, constantsEditors, mapEditors, nil)
+}
+
+// CloneProgramWithSpecEditor - does the same thing as CloneProgram, but allows to intercept the new program spec before the probe
+// is initialized. This is useful for example to clone an fentry probe, and edit the AttachTo field before the init of the new probe.
 func (m *Manager) CloneProgramWithSpecEditor(UID string, newProbe *Probe, constantsEditors []ConstantEditor, mapEditors map[string]*ebpf.Map, specEditor func(spec *ebpf.ProgramSpec)) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()


### PR DESCRIPTION
### What does this PR do?

It can be useful to edit the programspec during a clone operation, especially when managing fentry probes. This PR adds a new method to the manager `CloneProgramWithSpecEditor` extending `CloneProgram` with a callback allowing spec modification.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
