### PR TITLE
update ebpf lib to reduce map allocs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/ebpf-manager
 go 1.21.0
 
 require (
-	github.com/cilium/ebpf v0.15.1-0.20240709101333-5976561b28aa
+	github.com/cilium/ebpf v0.15.1-0.20240723161354-061e86d8f5e9
 	github.com/vishvananda/netlink v1.2.1-beta.2.0.20230807190133-6afddb37c1f0
 	github.com/vishvananda/netns v0.0.4
 	golang.org/x/sys v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cilium/ebpf v0.15.1-0.20240709101333-5976561b28aa h1:b4/gKHzwOL8b2p1y6yICwS2kUgaZgJs9qpcYmJS9+NE=
-github.com/cilium/ebpf v0.15.1-0.20240709101333-5976561b28aa/go.mod h1:L7u2Blt2jMM/vLAVgjxluxtBKlz3/GWjB0dMOEngfwE=
+github.com/cilium/ebpf v0.15.1-0.20240723161354-061e86d8f5e9 h1:WxQmRj9AESSm24SPxsOfa+BmWfKjzycCDvk3HAYEe20=
+github.com/cilium/ebpf v0.15.1-0.20240723161354-061e86d8f5e9/go.mod h1:L7u2Blt2jMM/vLAVgjxluxtBKlz3/GWjB0dMOEngfwE=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=


### PR DESCRIPTION
### What does this PR do?

https://github.com/cilium/ebpf/commit/63c6cf8fc5b2c94aa755c8ef64fb95e9e3be3d23 removes allocs for error when key is missing

### Motivation

Reduced memory allocations.

### Additional Notes


### Describe how to test your changes


