### PR TITLE
prevent multiple calls to LoadELF

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -430,7 +430,7 @@ func (m *Manager) GetProbe(id ProbeIdentificationPair) (*Probe, bool) {
 func (m *Manager) LoadELF(elf io.ReaderAt) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.state > elfLoaded {
+	if m.state >= elfLoaded {
 		return ErrManagerELFLoaded
 	}
 	return m.loadELF(elf)

--- a/manager_test.go
+++ b/manager_test.go
@@ -261,3 +261,20 @@ func TestInstructionPatching(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestLoadELF(t *testing.T) {
+	f, err := os.Open("testdata/patching.elf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	m := &Manager{
+		state: reset,
+	}
+	if err = m.LoadELF(f); err != nil {
+		t.Errorf("LoadELF() error = %v, wantErr %v", err, nil)
+	}
+	if err = m.LoadELF(f); errors.Is(err, ErrManagerELFLoaded) {
+		t.Errorf("LoadELF() error = %v, wantErr %v", err, ErrManagerELFLoaded)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

fixes a potential state corruption if LoadElf is called more than once on the same manager

### Motivation

If one Elf is already loaded, we shouldn't allow further calls (similar to Init/InitWithOptions logic)

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

added a UT
