### PR TITLE
Remove Rlimit only when eBPF does not account memory to cgroup

### DIFF
--- a/examples/mapspec_editor/main.go
+++ b/examples/mapspec_editor/main.go
@@ -5,10 +5,8 @@ import (
 	_ "embed"
 	"fmt"
 	"log"
-	"math"
 
 	"github.com/cilium/ebpf"
-	"golang.org/x/sys/unix"
 
 	manager "github.com/DataDog/ebpf-manager"
 )
@@ -33,10 +31,7 @@ func run() error {
 				EditorFlag: manager.EditMaxEntries | manager.EditType,
 			},
 		},
-		RLimit: &unix.Rlimit{
-			Cur: math.MaxUint64,
-			Max: math.MaxUint64,
-		},
+		RemoveRlimit: true,
 	}
 
 	if err := m.InitWithOptions(bytes.NewReader(Probe), options); err != nil {

--- a/manager_test.go
+++ b/manager_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"math"
 	"os"
 	"strings"
 	"testing"
@@ -12,7 +11,6 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/rlimit"
-	"golang.org/x/sys/unix"
 )
 
 func TestVerifierError(t *testing.T) {
@@ -60,10 +58,7 @@ func TestExclude(t *testing.T) {
 		},
 	}
 	opts := Options{
-		RLimit: &unix.Rlimit{
-			Cur: math.MaxUint64,
-			Max: math.MaxUint64,
-		},
+		RemoveRlimit: true,
 		ExcludedMaps: []string{"map_two"},
 	}
 


### PR DESCRIPTION
### What does this PR do?
This PR uses the eBPF loader library helper for removing the rlimit on locked memory. This helper only removes the limit when eBPF does not account memory to cgroup, which was introduced in the kernel with this [patch](https://lore.kernel.org/bpf/20201201215900.3569844-1-guro@fb.com/t/). Prior to this patch the kernel used rlimit based accounting to calculate how much memory could be used for eBPF maps. For these kernels the loader will set the limit to infinity.

Moreover, since all users of the `RLimit` option set the limit to the max, this option has been changed to a boolean `RemoveRlimit`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
