### PR TITLE
add callback based constant editor

### DIFF
--- a/constant_editor.go
+++ b/constant_editor.go
@@ -17,6 +17,9 @@ type ConstantEditor struct {
 	// Value - Value to write in the eBPF bytecode. When using the asm load method, the Value has to be a `uint64`.
 	Value interface{}
 
+	// ValueCallback - Called to get the value to write in the eBPF bytecode
+	ValueCallback func(prog *ebpf.ProgramSpec) interface{}
+
 	// FailOnMissing - If FailOMissing is set to true, the constant edition process will return an error if the constant
 	// was missing in at least one program
 	FailOnMissing bool
@@ -27,6 +30,13 @@ type ConstantEditor struct {
 	// ProbeIdentificationPairs - Identifies the list of programs to edit. If empty, it will apply to all the programs
 	// of the manager. Will return an error if at least one edition failed.
 	ProbeIdentificationPairs []ProbeIdentificationPair
+}
+
+func (ce *ConstantEditor) GetValue(prog *ebpf.ProgramSpec) interface{} {
+	if ce.ValueCallback != nil {
+		return ce.ValueCallback(prog)
+	}
+	return ce.Value
 }
 
 // editConstants - newEditor the programs in the CollectionSpec with the provided constant editors. Tries with the BTF global
@@ -40,7 +50,7 @@ func (m *Manager) editConstants() error {
 				continue
 			}
 			constant := map[string]interface{}{
-				editor.Name: editor.Value,
+				editor.Name: editor.GetValue(nil), // in BTF mode, we don't have access to the hooked program
 			}
 			if err := m.collectionSpec.RewriteConstants(constant); err != nil && editor.FailOnMissing {
 				return err
@@ -88,7 +98,7 @@ func (m *Manager) editConstants() error {
 				edit = newEditor(&prog.Instructions)
 			}
 
-			if err := m.editConstantWithEditor(edit, constantEditor); err != nil {
+			if err := m.editConstantWithEditor(prog, edit, constantEditor); err != nil {
 				return fmt.Errorf("couldn't edit %s in %s: %w", constantEditor.Name, section, err)
 			}
 		}
@@ -100,11 +110,11 @@ func (m *Manager) editConstants() error {
 // editConstant - newEditor the provided program with the provided constant using the asm method.
 func (m *Manager) editConstant(prog *ebpf.ProgramSpec, editor ConstantEditor) error {
 	edit := newEditor(&prog.Instructions)
-	return m.editConstantWithEditor(edit, editor)
+	return m.editConstantWithEditor(prog, edit, editor)
 }
 
-func (m *Manager) editConstantWithEditor(edit *editor, editor ConstantEditor) error {
-	data, ok := (editor.Value).(uint64)
+func (m *Manager) editConstantWithEditor(prog *ebpf.ProgramSpec, edit *editor, editor ConstantEditor) error {
+	data, ok := (editor.GetValue(prog)).(uint64)
 	if !ok {
 		return fmt.Errorf("with the asm method, the constant value has to be of type uint64")
 	}


### PR DESCRIPTION
### What does this PR do?

This PR adds a new field to the constant editor, allowing to provide a callback to get the value of the constant instead of the direct value.

This is useful for example if you want the value to differ depending on the program.

### Motivation

In the agent, I want a constant to represent the amount of arguments taken by the hooked function. This will allow me to do that.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
