### PR TITLE
check for `FailOnMissing` before the error type check

### DIFF
--- a/constant_editor.go
+++ b/constant_editor.go
@@ -119,7 +119,7 @@ func (m *Manager) editConstantWithEditor(prog *ebpf.ProgramSpec, edit *editor, e
 		return fmt.Errorf("with the asm method, the constant value has to be of type uint64")
 	}
 	if err := edit.RewriteConstant(editor.Name, data); err != nil {
-		if isUnreferencedSymbol(err) && editor.FailOnMissing {
+		if editor.FailOnMissing && isUnreferencedSymbol(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

`isUnreferencedSymbol` actually allocates some memory, so checking first for `FailOnMissing` allows this check to not allocate in most cases (especially `FailOnMissing` is never used in the agent).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
