### PR TITLE
remove support for frozen maps

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1310,7 +1310,6 @@ func (m *Manager) matchSpecs() error {
 			return fmt.Errorf("couldn't find map at maps/%s: %w", managerMap.Name, ErrUnknownSection)
 		}
 		spec.Contents = managerMap.Contents
-		spec.Freeze = managerMap.Freeze
 		managerMap.arraySpec = spec
 	}
 

--- a/map.go
+++ b/map.go
@@ -48,9 +48,6 @@ type Map struct {
 	// Contents - The initial contents of the map. May be nil.
 	Contents []ebpf.MapKV
 
-	// Freeze - Whether to freeze a map after setting its initial contents.
-	Freeze bool
-
 	// Other options
 	MapOptions
 }
@@ -62,7 +59,6 @@ func loadNewMap(spec *ebpf.MapSpec, options MapOptions) (*Map, error) {
 		arraySpec:  spec,
 		Name:       spec.Name,
 		Contents:   spec.Contents,
-		Freeze:     spec.Freeze,
 		MapOptions: options,
 	}
 


### PR DESCRIPTION
### What does this PR do?

The map `Freeze` field was removed by the upstream cilium/ebpf lib in https://github.com/cilium/ebpf/pull/1558. This PR removes the support for this field in the ebpf-manager since this field is not used in the agent either.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
