### PR TITLE
Make TC filter count thread-safe

### DIFF
--- a/netlink.go
+++ b/netlink.go
@@ -14,7 +14,7 @@ import (
 // TC filter count
 type NetlinkSocket struct {
 	Sock          *netlink.Handle
-	filterMutex sync.Mutex
+	filterMutex   sync.Mutex
 	tcFilterCount map[int]int
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR ensures that the `tcFilterCount` field used in TC probes is thread-safe.

### Motivation

After #212 was introduced, data races were detected when multiple TC probes stopped at the same time.

### Additional Notes

### Describe how to test your changes

Tested in datadog-agent CI: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/53780200
