### PR TITLE
update cilium/ebpf to v0.17.1

### DIFF
--- a/constant_editor.go
+++ b/constant_editor.go
@@ -56,8 +56,12 @@ func (m *Manager) editConstants() error {
 				}
 				continue
 			}
+			if !vs.Constant() {
+				return fmt.Errorf("variable %s is not a constant", editor.Name)
+			}
+
 			if err := vs.Set(editor.GetValue(nil)); err != nil {
-				return err
+				return fmt.Errorf("edit constant %s: %s", editor.Name, err)
 			}
 		}
 	}

--- a/constant_editor.go
+++ b/constant_editor.go
@@ -49,10 +49,14 @@ func (m *Manager) editConstants() error {
 			if !editor.BTFGlobalConstant {
 				continue
 			}
-			constant := map[string]interface{}{
-				editor.Name: editor.GetValue(nil), // in BTF mode, we don't have access to the hooked program
+			vs, ok := m.collectionSpec.Variables[editor.Name]
+			if !ok {
+				if editor.FailOnMissing {
+					return fmt.Errorf("variable %s not found", editor.Name)
+				}
+				continue
 			}
-			if err := m.collectionSpec.RewriteConstants(constant); err != nil && editor.FailOnMissing {
+			if err := vs.Set(editor.GetValue(nil)); err != nil {
 				return err
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,9 @@ module github.com/DataDog/ebpf-manager
 go 1.22.0
 
 require (
-	github.com/cilium/ebpf v0.16.0
+	github.com/cilium/ebpf v0.17.2-0.20250115131724-fd1fe1b9ac25
 	github.com/vishvananda/netlink v1.3.0
 	github.com/vishvananda/netns v0.0.5
 	golang.org/x/sync v0.10.0
 	golang.org/x/sys v0.29.0
 )
-
-require golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/ebpf-manager
 go 1.22.0
 
 require (
-	github.com/cilium/ebpf v0.17.2-0.20250115131724-fd1fe1b9ac25
+	github.com/cilium/ebpf v0.17.2
 	github.com/vishvananda/netlink v1.3.0
 	github.com/vishvananda/netns v0.0.5
 	golang.org/x/sync v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cilium/ebpf v0.17.2-0.20250115131724-fd1fe1b9ac25 h1:qUEMbtIICjyaxgiPD5uJYfMLdNdxsbtbplS+gXUrJAM=
-github.com/cilium/ebpf v0.17.2-0.20250115131724-fd1fe1b9ac25/go.mod h1:9X5VAsIOck/nCAp0+nCSVzub1Q7x+zKXXItTMYfNE+E=
+github.com/cilium/ebpf v0.17.2 h1:IQTaTVu0vKA8WTemFuBnxW9YbAwMkJVKHsNHW4lHv/g=
+github.com/cilium/ebpf v0.17.2/go.mod h1:9X5VAsIOck/nCAp0+nCSVzub1Q7x+zKXXItTMYfNE+E=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cilium/ebpf v0.16.0 h1:+BiEnHL6Z7lXnlGUsXQPPAE7+kenAd4ES8MQ5min0Ok=
-github.com/cilium/ebpf v0.16.0/go.mod h1:L7u2Blt2jMM/vLAVgjxluxtBKlz3/GWjB0dMOEngfwE=
+github.com/cilium/ebpf v0.17.2-0.20250115131724-fd1fe1b9ac25 h1:qUEMbtIICjyaxgiPD5uJYfMLdNdxsbtbplS+gXUrJAM=
+github.com/cilium/ebpf v0.17.2-0.20250115131724-fd1fe1b9ac25/go.mod h1:9X5VAsIOck/nCAp0+nCSVzub1Q7x+zKXXItTMYfNE+E=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -23,10 +23,8 @@ github.com/vishvananda/netlink v1.3.0/go.mod h1:i6NetklAujEcC6fK0JPjT8qSwWyO0HLn
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
-golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 h1:m64FZMko/V45gv0bNmrNYoDEq8U5YUhetc9cBWKS1TQ=
-golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63/go.mod h1:0v4NqG35kSWCMzLaMeX+IQrlSnVE/bqGSyC2cz/9Le8=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
### What does this PR do?

Updates `cilium/ebpf` to v0.17.1

### Motivation



### Additional Notes

Also includes a bugfix to kernel module BTF functionality: https://github.com/cilium/ebpf/commit/fd1fe1b9ac2532d2aec6cc70e05e24e305f78f19

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
