### PR TITLE
improve cleanup when stopping

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -938,6 +938,14 @@ func (m *Manager) Stop(cleanup MapCleanupType) error {
 	return m.stop(cleanup)
 }
 
+// ForceStop - Detach all eBPF programs and stop perf ring readers, ignore the previous state. The cleanup parameter defines which maps should be closed.
+// See MapCleanupType for mode.
+func (m *Manager) ForceStop(cleanup MapCleanupType) error {
+	m.stateLock.Lock()
+	defer m.stateLock.Unlock()
+	return m.stop(cleanup)
+}
+
 // StopReaders stop the kernel events readers Perf or Ring buffer
 func (m *Manager) StopReaders(cleanup MapCleanupType) error {
 	m.stateLock.Lock()

--- a/map.go
+++ b/map.go
@@ -94,7 +94,7 @@ func (m *Map) Close(cleanup MapCleanupType) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
 	if m.state < initialized {
-		return ErrMapInitialized
+		return ErrMapNotInitialized
 	}
 	return m.close(cleanup)
 }


### PR DESCRIPTION
### What does this PR do?

Allow to force stop a manager that failed to start and which is in an unknown state. It fixes the state machine of perf/ringbuf map so that the manager can be stopped and then restarted using different options.

The main goal is to support : 
1. use fentry
2. if fentry fails, fallback to kprobes.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
