### PR TITLE
update to go 1.23 and 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: staticcheck
         uses: dominikh/staticcheck-action@fe1dd0c3658873b46f8c9bb3291096a617310ca6 #v1.3.1
         with:
-          version: "56172d41b117cc2c2f99f65fe0a790c8d7d7ea66" #2024.1.1
+          version: "5af2e5fc3b08ba46027eb48ebddeba34dc0bd02c" #2025.1
           install-go: false
           cache-key: ${{ matrix.go }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ "1.22", "1.23" ]
+        go: [ "1.23", "1.24" ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/ebpf-manager
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/cilium/ebpf v0.17.2


### PR DESCRIPTION
### What does this PR do?

update to go 1.23 and 1.24

### Motivation

1.22 no longer supported

### Additional Notes



### Describe how to test your changes

