### PR TITLE
do not try fallback attach method if start returned ErrNotSupported

### DIFF
--- a/uprobe.go
+++ b/uprobe.go
@@ -138,15 +138,17 @@ func (p *Probe) attachUprobe() error {
 		return &tracefsLink{perfEventLink: newPerfEventLink(pfd), Type: uprobe}, nil
 	}
 
+	pmuFirst := true
 	startFunc, fallbackFunc := pmuFunc, eventsFunc
 	if p.UprobeAttachMethod == AttachWithProbeEvents {
+		pmuFirst = false
 		startFunc, fallbackFunc = eventsFunc, pmuFunc
 	}
 
 	var startErr, fallbackErr error
 	var tl *tracefsLink
 	if tl, startErr = startFunc(); startErr != nil {
-		if !errors.Is(startErr, ErrNotSupported) {
+		if pmuFirst && !errors.Is(startErr, ErrNotSupported) {
 			return startErr
 		}
 

--- a/uprobe.go
+++ b/uprobe.go
@@ -148,6 +148,8 @@ func (p *Probe) attachUprobe() error {
 	var startErr, fallbackErr error
 	var tl *tracefsLink
 	if tl, startErr = startFunc(); startErr != nil {
+		// do not fallback on tracefs events if PMU attach method is supported
+		// and we got an actual error from it
 		if pmuFirst && !errors.Is(startErr, ErrNotSupported) {
 			return startErr
 		}

--- a/uprobe.go
+++ b/uprobe.go
@@ -146,6 +146,10 @@ func (p *Probe) attachUprobe() error {
 	var startErr, fallbackErr error
 	var tl *tracefsLink
 	if tl, startErr = startFunc(); startErr != nil {
+		if !errors.Is(startErr, ErrNotSupported) {
+			return startErr
+		}
+
 		if tl, fallbackErr = fallbackFunc(); fallbackErr != nil {
 			return errors.Join(startErr, fallbackErr)
 		}


### PR DESCRIPTION
### What does this PR do?

When attaching a uprobe, by default, we currently first try to attach using PMU and if it fails (for any reason) we fallback on tracefs.

Falling back on tracefs is only needed if the PMU failure is related to it not being supported, if the failure is related to the arguments themselves it doesn't really make sense to fallback on tracefs

This also brings the benefit of limiting the amount of potential failing tracefs calls that can trigger a kernel oops, see https://lore.kernel.org/all/20221121081103.3070449-1-zhengyejian1@huawei.com/T/ for more info.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
