### PR TITLE
Expose perf event fd

### DIFF
--- a/kprobe.go
+++ b/kprobe.go
@@ -65,6 +65,15 @@ func (p *Probe) attachKprobe() error {
 	return nil
 }
 
+func (p *Probe) PerfEventFD() (uint32, error) {
+	v, ok := p.progLink.(*tracefsLink)
+	if !ok {
+		return 0, fmt.Errorf("Probe %q does not have a perf event link", p.programSpec.Name)
+	}
+
+	return v.perfEventLink.fd.Value()
+}
+
 // attachWithKprobeEvents attaches the kprobe using the kprobes_events ABI
 func (p *Probe) attachWithKprobeEvents() (*tracefsLink, error) {
 	if p.kprobeHookPointNotExist {

--- a/kprobe.go
+++ b/kprobe.go
@@ -65,6 +65,7 @@ func (p *Probe) attachKprobe() error {
 	return nil
 }
 
+// PerfEventFD returns the associated perf event's fd for this Probe
 func (p *Probe) PerfEventFD() (uint32, error) {
 	v, ok := p.progLink.(*tracefsLink)
 	if !ok {


### PR DESCRIPTION
### What does this PR do?

This PR adds a method to the `Probe` object for exposing the associated perf event fd if present.

### Motivation

This fd is intended to be used in the agent for triggering stat collection of the perf event.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
