### PR TITLE
add section parsing for raw tracepoints

### DIFF
--- a/raw_tp.go
+++ b/raw_tp.go
@@ -2,12 +2,21 @@ package manager
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cilium/ebpf/link"
 )
 
 // attachRawTracepoint - Attaches the probe to its raw_tracepoint
 func (p *Probe) attachRawTracepoint() error {
+	if len(p.TracepointName) == 0 {
+		traceGroup := strings.SplitN(p.programSpec.SectionName, "/", 2)
+		if len(traceGroup) != 2 {
+			return fmt.Errorf(`expected SEC("raw_tp/[name]") or SEC("raw_tracepoint/[name]") got %s: %w`, p.programSpec.SectionName, ErrSectionFormat)
+		}
+		p.TracepointName = traceGroup[1]
+	}
+
 	var err error
 	p.progLink, err = link.AttachRawTracepoint(link.RawTracepointOptions{
 		Name:    p.TracepointName,


### PR DESCRIPTION
### What does this PR do?

Parses the section name to obtain the `TracepointName` for a raw tracepoint

### Motivation

Fixes #239