### PR TITLE
bump cilium/ebpf to fix rebase decoder error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/ebpf-manager
 go 1.23.0
 
 require (
-	github.com/cilium/ebpf v0.18.0
+	github.com/cilium/ebpf v0.19.1-0.20250815124406-a785455afa54
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vishvananda/netns v0.0.5
 	golang.org/x/sync v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cilium/ebpf v0.18.0 h1:OsSwqS4y+gQHxaKgg2U/+Fev834kdnsQbtzRnbVC6Gs=
-github.com/cilium/ebpf v0.18.0/go.mod h1:vmsAT73y4lW2b4peE+qcOqw6MxvWQdC+LiU5gd/xyo4=
+github.com/cilium/ebpf v0.19.1-0.20250815124406-a785455afa54 h1:pfSDSv3XIG2zESzrVms49zf76BkLt8BZPcsaNgxThMU=
+github.com/cilium/ebpf v0.19.1-0.20250815124406-a785455afa54/go.mod h1:fLCgMo3l8tZmAdM3B2XqdFzXBpwkcSTroaVqN08OWVY=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -22,8 +22,8 @@ github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW
 github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
-golang.org/x/net v0.36.0 h1:vWF2fRbw4qslQsQzgFqZff+BItCvGFQqKzKIzx1rmoA=
-golang.org/x/net v0.36.0/go.mod h1:bFmbeoIPfrw4sMHNhb4J9f6+tPziuGjq7Jk/38fxi1I=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
 golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/manager.go
+++ b/manager.go
@@ -109,7 +109,7 @@ type Options struct {
 	// `RLIMIT_MEMLOCK` If a limit is provided here it will be applied when the manager is initialized.
 	RemoveRlimit bool
 
-	// KeepKernelBTF - Defines if the kernel types defined in VerifierOptions.Programs.KernelTypes and KernelModuleTypes should be cleaned up
+	// KeepKernelBTF - Defines if the kernel types defined in VerifierOptions.Programs.KernelTypes should be cleaned up
 	// once the manager is done using them. By default, the manager will clean them up to save up space. DISCLAIMER: if
 	// your program uses "manager.CloneProgram", you might want to enable "KeepKernelBTF". As a workaround, you can also
 	// try to strip as much as possible the content of "KernelTypes" to reduce the memory overhead.
@@ -785,7 +785,6 @@ func (m *Manager) Start() error {
 	if !m.options.KeepKernelBTF {
 		// release kernel BTF. It should no longer be needed
 		m.options.VerifierOptions.Programs.KernelTypes = nil
-		m.options.VerifierOptions.Programs.KernelModuleTypes = nil
 	}
 
 	// clean up tracefs


### PR DESCRIPTION
### What does this PR do?

We recently merged https://github.com/cilium/ebpf/commit/a785455afa5409a76645e51d4bc0319714e4e1f0 upstream to fix some infrequent errors we were seeing internally, looking like:
```
2025-08-15 08:13:31 UTC | SYS-PROBE | ERROR | (pkg/system-probe/api/module/loader_linux.go:55 in postRegister) | failed to initialize ebpf lock contention collector: unable to fetch kernel symbol addresses: failed to load objects: field BpfIteratorDumpKsyms: program bpf_iter__dump_ksyms: apply CO-RE relocations: load BTF for kmod cls_bpf: rebase split spec: raw BTF differs (base address differs)
```

This PR bumps cilium/ebpf to the commit including the fix, sadly this also includes a breaking change related to `KernelModuleTypes` preventing us from simply upgrading on the agent only.


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes and instructions on how this should be tested.
