### PR TITLE
Check if ebpf.ProgramSpec is not nil before returning to user

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -387,7 +387,7 @@ func (m *Manager) getProgramSpec(id ProbeIdentificationPair) ([]*ebpf.ProgramSpe
 	var programs []*ebpf.ProgramSpec
 	if id.UID == "" {
 		for _, probe := range m.Probes {
-			if probe.EBPFFuncName == id.EBPFFuncName {
+			if probe.EBPFFuncName == id.EBPFFuncName && probe.programSpec != nil {
 				programs = append(programs, probe.programSpec)
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

`manager.GetProgramSpec` returns `Probe.programSpec` even if it is nil. This can happen when this function is called after `manager.LoadELF` but before initialization, even though ebpf.CollectionSpec is populated.

### Motivation


### Additional Notes


### Describe how to test your changes

