### PR TITLE
add state to socketLink to prevent errors

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -1,41 +1,76 @@
 package manager
 
 import (
+	"errors"
+	"sync"
 	"syscall"
 
 	"golang.org/x/sys/unix"
 )
 
 // attachSocket - Attaches the probe to the provided socket
-func (p *Probe) attachSocket() error {
-	if err := sockAttach(p.SocketFD, p.program.FD()); err != nil {
-		return err
+func (p *Probe) attachSocket() (err error) {
+	p.progLink, err = newSocketLink(p.SocketFD, p.program.FD())
+	return
+}
+
+func newSocketLink(sockFD int, progFD int) (*socketLink, error) {
+	sl := &socketLink{
+		sockFD: sockFD,
+		progFD: progFD,
 	}
-	p.progLink = &socketLink{p.SocketFD, p.program.FD()}
-	return nil
+	if err := sl.attach(); err != nil {
+		return nil, err
+	}
+	return sl, nil
 }
 
 type socketLink struct {
-	sockFD int
-	progFD int
+	mtx      sync.Mutex
+	attached bool
+	sockFD   int
+	progFD   int
+}
+
+func (s *socketLink) detach() error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if !s.attached {
+		return nil
+	}
+
+	if err := syscall.SetsockoptInt(s.sockFD, syscall.SOL_SOCKET, unix.SO_DETACH_BPF, s.progFD); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			s.attached = false
+		}
+		return err
+	}
+	s.attached = false
+	return nil
+}
+
+func (s *socketLink) attach() error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if s.attached {
+		return nil
+	}
+
+	if err := syscall.SetsockoptInt(s.sockFD, syscall.SOL_SOCKET, unix.SO_ATTACH_BPF, s.progFD); err != nil {
+		return err
+	}
+	s.attached = true
+	return nil
 }
 
 func (s *socketLink) Close() error {
-	return sockDetach(s.sockFD, s.progFD)
+	return s.detach()
 }
 
 func (s *socketLink) Pause() error {
-	return sockDetach(s.sockFD, s.progFD)
+	return s.detach()
 }
 
 func (s *socketLink) Resume() error {
-	return sockAttach(s.sockFD, s.progFD)
-}
-
-func sockAttach(sockFd int, progFd int) error {
-	return syscall.SetsockoptInt(sockFd, syscall.SOL_SOCKET, unix.SO_ATTACH_BPF, progFd)
-}
-
-func sockDetach(sockFd int, progFd int) error {
-	return syscall.SetsockoptInt(sockFd, syscall.SOL_SOCKET, unix.SO_DETACH_BPF, progFd)
+	return s.attach()
 }

--- a/socket.go
+++ b/socket.go
@@ -9,9 +9,13 @@ import (
 )
 
 // attachSocket - Attaches the probe to the provided socket
-func (p *Probe) attachSocket() (err error) {
-	p.progLink, err = newSocketLink(p.SocketFD, p.program.FD())
-	return
+func (p *Probe) attachSocket() error {
+	sl, err := newSocketLink(p.SocketFD, p.program.FD())
+	if err != nil {
+		return err
+	}
+	p.progLink = sl
+	return nil
 }
 
 func newSocketLink(sockFD int, progFD int) (*socketLink, error) {


### PR DESCRIPTION
### What does this PR do?

Adds `attached` state to `socketLink`

### Motivation

If you called `Pause()` then `Close()`, it would result in an error

### Additional Notes


### Describe how to test your changes

