### PR TITLE
Fix panic when call cleanupMap twice

### DIFF
--- a/perfmap.go
+++ b/perfmap.go
@@ -252,6 +252,10 @@ func (m *PerfMap) closeReader() error {
 func (m *PerfMap) cleanupMap(cleanup MapCleanupType) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
+	// check if map was already closed
+	if m.state == reset {
+		return nil
+	}
 	return m.close(cleanup)
 }
 

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -201,6 +201,10 @@ func (rb *RingBuffer) closeReader() error {
 func (rb *RingBuffer) cleanupMap(cleanup MapCleanupType) error {
 	rb.stateLock.Lock()
 	defer rb.stateLock.Unlock()
+	// check if map was already closed
+	if rb.state == reset {
+		return nil
+	}
 	return rb.close(cleanup)
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR fix a panic that was introduced by [the previous PR](https://github.com/DataDog/ebpf-manager/pull/288).
Before, when the function `Stop` was not splitted, this could not happen since the state was checked at the beginning of the function. We know need to check it in both functions.

### Motivation
Calling 2 times cleanupMap could panic since we try to close a map that was already close.
What inspired you to submit this pull request?
