### PR TITLE
Fix UpdateActivatedProbes panic, refactor state checks, use stopping state

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -171,7 +171,12 @@ type Manager struct {
 func (m *Manager) DumpMaps(w io.Writer, maps ...string) error {
 	m.stateLock.RLock()
 	defer m.stateLock.RUnlock()
-	if m.collection == nil || m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
+		return ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+	}
+	if m.collection == nil {
 		return ErrManagerNotInitialized
 	}
 
@@ -230,7 +235,12 @@ func (m *Manager) getMap(name string) (*ebpf.Map, bool, error) {
 func (m *Manager) GetMap(name string) (*ebpf.Map, bool, error) {
 	m.stateLock.RLock()
 	defer m.stateLock.RUnlock()
-	if m.collection == nil || m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
+		return nil, false, ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+	}
+	if m.collection == nil {
 		return nil, false, ErrManagerNotInitialized
 	}
 	return m.getMap(name)
@@ -240,7 +250,12 @@ func (m *Manager) GetMap(name string) (*ebpf.Map, bool, error) {
 func (m *Manager) GetMaps() (map[string]*ebpf.Map, error) {
 	m.stateLock.RLock()
 	defer m.stateLock.RUnlock()
-	if m.collection == nil || m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
+		return nil, ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+	}
+	if m.collection == nil {
 		return nil, ErrManagerNotInitialized
 	}
 
@@ -276,7 +291,12 @@ func (m *Manager) getMapSpec(name string) (*ebpf.MapSpec, bool, error) {
 func (m *Manager) GetMapSpec(name string) (*ebpf.MapSpec, bool, error) {
 	m.stateLock.RLock()
 	defer m.stateLock.RUnlock()
-	if m.collectionSpec == nil || m.state < elfLoaded {
+	switch m.state {
+	case reset:
+		return nil, false, ErrManagerNotELFLoaded
+	case elfLoaded, initialized, stopping, paused, running:
+	}
+	if m.collectionSpec == nil {
 		return nil, false, ErrManagerNotELFLoaded
 	}
 	return m.getMapSpec(name)
@@ -346,7 +366,12 @@ func (m *Manager) getProgram(id ProbeIdentificationPair) ([]*ebpf.Program, bool,
 func (m *Manager) GetProgram(id ProbeIdentificationPair) ([]*ebpf.Program, bool, error) {
 	m.stateLock.RLock()
 	defer m.stateLock.RUnlock()
-	if m.collection == nil || m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
+		return nil, false, ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+	}
+	if m.collection == nil {
 		return nil, false, ErrManagerNotInitialized
 	}
 	return m.getProgram(id)
@@ -356,7 +381,12 @@ func (m *Manager) GetProgram(id ProbeIdentificationPair) ([]*ebpf.Program, bool,
 func (m *Manager) GetPrograms() (map[string]*ebpf.Program, error) {
 	m.stateLock.RLock()
 	defer m.stateLock.RUnlock()
-	if m.collection == nil || m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
+		return nil, ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+	}
+	if m.collection == nil {
 		return nil, ErrManagerNotInitialized
 	}
 
@@ -367,7 +397,12 @@ func (m *Manager) GetPrograms() (map[string]*ebpf.Program, error) {
 func (m *Manager) GetMapSpecs() (map[string]*ebpf.MapSpec, error) {
 	m.stateLock.RLock()
 	defer m.stateLock.RUnlock()
-	if m.collectionSpec == nil || m.state < elfLoaded {
+	switch m.state {
+	case reset:
+		return nil, ErrManagerNotELFLoaded
+	case elfLoaded, initialized, stopping, paused, running:
+	}
+	if m.collectionSpec == nil {
 		return nil, ErrManagerNotELFLoaded
 	}
 
@@ -378,7 +413,12 @@ func (m *Manager) GetMapSpecs() (map[string]*ebpf.MapSpec, error) {
 func (m *Manager) GetProgramSpecs() (map[string]*ebpf.ProgramSpec, error) {
 	m.stateLock.RLock()
 	defer m.stateLock.RUnlock()
-	if m.collectionSpec == nil || m.state < elfLoaded {
+	switch m.state {
+	case reset:
+		return nil, ErrManagerNotELFLoaded
+	case elfLoaded, initialized, stopping, paused, running:
+	}
+	if m.collectionSpec == nil {
 		return nil, ErrManagerNotELFLoaded
 	}
 
@@ -415,7 +455,12 @@ func (m *Manager) getProgramSpec(id ProbeIdentificationPair) ([]*ebpf.ProgramSpe
 func (m *Manager) GetProgramSpec(id ProbeIdentificationPair) ([]*ebpf.ProgramSpec, bool, error) {
 	m.stateLock.RLock()
 	defer m.stateLock.RUnlock()
-	if m.collectionSpec == nil || m.state < elfLoaded {
+	switch m.state {
+	case reset:
+		return nil, false, ErrManagerNotELFLoaded
+	case elfLoaded, initialized, stopping, paused, running:
+	}
+	if m.collectionSpec == nil {
 		return nil, false, ErrManagerNotELFLoaded
 	}
 	return m.getProgramSpec(id)
@@ -450,10 +495,13 @@ func (m *Manager) GetProbe(id ProbeIdentificationPair) (*Probe, bool) {
 func (m *Manager) LoadELF(elf io.ReaderAt) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.state >= elfLoaded {
+	switch m.state {
+	case reset:
+		return m.loadELF(elf)
+	case elfLoaded, initialized, stopping, paused, running:
 		return ErrManagerELFLoaded
 	}
-	return m.loadELF(elf)
+	return nil
 }
 
 func (m *Manager) loadELF(elf io.ReaderAt) error {
@@ -495,8 +543,10 @@ func (m *Manager) initState(elf io.ReaderAt, options Options) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
 
-	if m.state > initialized {
+	switch m.state {
+	case stopping, paused, running:
 		return ErrManagerRunning
+	case reset, elfLoaded, initialized:
 	}
 
 	m.options = options
@@ -520,16 +570,18 @@ func (m *Manager) initState(elf io.ReaderAt, options Options) error {
 		}
 	}
 
-	if m.state < elfLoaded {
+	switch m.state {
+	case reset:
 		if elf == nil {
 			return fmt.Errorf("nil ELF reader")
 		}
-
 		if err := m.loadELF(elf); err != nil {
 			return err
 		}
-	} else if elf != nil {
-		return ErrManagerELFLoaded
+	case elfLoaded, initialized, stopping, paused, running:
+		if elf != nil {
+			return ErrManagerELFLoaded
+		}
 	}
 
 	if m.options.AdditionalExcludedFunctionCollector != nil {
@@ -788,13 +840,14 @@ func (m *Manager) releaseKernelBTF() {
 // Start - Attach eBPF programs, start perf ring readers and apply maps and tail calls routing.
 func (m *Manager) Start() error {
 	m.stateLock.Lock()
-	if m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
 		m.stateLock.Unlock()
 		return ErrManagerNotInitialized
-	}
-	if m.state >= running {
+	case running:
 		m.stateLock.Unlock()
 		return nil
+	case initialized, stopping, paused:
 	}
 
 	// release kernel BTF: it is only needed while loading programs and should no longer be needed now
@@ -874,11 +927,12 @@ func (m *Manager) Start() error {
 func (m *Manager) Pause() error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.state == paused {
+	switch m.state {
+	case paused:
 		return nil
-	}
-	if m.state <= initialized {
+	case reset, elfLoaded, initialized:
 		return ErrManagerNotStarted
+	case stopping, running:
 	}
 	if !m.options.BypassEnabled {
 		return nil
@@ -896,11 +950,12 @@ func (m *Manager) Pause() error {
 func (m *Manager) Resume() error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.state == running {
+	switch m.state {
+	case running:
 		return nil
-	}
-	if m.state <= initialized {
+	case reset, elfLoaded, initialized:
 		return ErrManagerNotStarted
+	case stopping, paused:
 	}
 	if !m.options.BypassEnabled {
 		return nil
@@ -920,10 +975,13 @@ func (m *Manager) Resume() error {
 func (m *Manager) Stop(cleanup MapCleanupType) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
 		return ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+		return m.stop(cleanup)
 	}
-	return m.stop(cleanup)
+	return nil
 }
 
 // StopReaders - Stop the kernel events readers Perf or Ring buffer.
@@ -1038,7 +1096,12 @@ func (m *Manager) stop(cleanup MapCleanupType) error {
 func (m *Manager) NewMap(spec *ebpf.MapSpec, options MapOptions) (*ebpf.Map, error) {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.collection == nil || m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
+		return nil, ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+	}
+	if m.collection == nil {
 		return nil, ErrManagerNotInitialized
 	}
 
@@ -1092,7 +1155,12 @@ func (m *Manager) CloneMap(name string, newName string, options MapOptions) (*eb
 func (m *Manager) AddHook(UID string, newProbe *Probe) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.collection == nil || m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
+		return ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+	}
+	if m.collection == nil {
 		return ErrManagerNotInitialized
 	}
 
@@ -1178,7 +1246,12 @@ func (m *Manager) AddHook(UID string, newProbe *Probe) error {
 func (m *Manager) DetachHook(id ProbeIdentificationPair) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.collection == nil || m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
+		return ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+	}
+	if m.collection == nil {
 		return ErrManagerNotInitialized
 	}
 
@@ -1227,7 +1300,12 @@ func (m *Manager) CloneProgram(UID string, newProbe *Probe, constantsEditors []C
 func (m *Manager) CloneProgramWithSpecEditor(UID string, newProbe *Probe, constantsEditors []ConstantEditor, mapEditors map[string]*ebpf.Map, specEditor func(spec *ebpf.ProgramSpec)) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.collection == nil || m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
+		return ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+	}
+	if m.collection == nil {
 		return ErrManagerNotInitialized
 	}
 
@@ -1472,9 +1550,11 @@ func (m *Manager) activateProbes() {
 // UpdateActivatedProbes - update the list of activated probes
 func (m *Manager) UpdateActivatedProbes(selectors []ProbesSelector) error {
 	m.stateLock.Lock()
-	if m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
 		m.stateLock.Unlock()
 		return ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
 	}
 
 	currentProbes := make(map[ProbeIdentificationPair]*Probe)

--- a/manager.go
+++ b/manager.go
@@ -841,13 +841,13 @@ func (m *Manager) releaseKernelBTF() {
 func (m *Manager) Start() error {
 	m.stateLock.Lock()
 	switch m.state {
-	case reset, elfLoaded:
+	case reset, elfLoaded, stopping:
 		m.stateLock.Unlock()
 		return ErrManagerNotInitialized
 	case running:
 		m.stateLock.Unlock()
 		return nil
-	case initialized, stopping, paused:
+	case initialized, paused:
 	}
 
 	// release kernel BTF: it is only needed while loading programs and should no longer be needed now
@@ -930,9 +930,9 @@ func (m *Manager) Pause() error {
 	switch m.state {
 	case paused:
 		return nil
-	case reset, elfLoaded, initialized:
+	case reset, elfLoaded, initialized, stopping:
 		return ErrManagerNotStarted
-	case stopping, running:
+	case running:
 	}
 	if !m.options.BypassEnabled {
 		return nil
@@ -953,9 +953,9 @@ func (m *Manager) Resume() error {
 	switch m.state {
 	case running:
 		return nil
-	case reset, elfLoaded, initialized:
+	case reset, elfLoaded, initialized, stopping:
 		return ErrManagerNotStarted
-	case stopping, paused:
+	case paused:
 	}
 	if !m.options.BypassEnabled {
 		return nil
@@ -985,8 +985,6 @@ func (m *Manager) Stop(cleanup MapCleanupType) error {
 }
 
 // StopReaders - Stop the kernel events readers Perf or Ring buffer.
-// It is not safe to call NewPerfRing or NewRingBuffer concurrently
-// with StopReaders since we cannot put state to reset here.
 func (m *Manager) StopReaders(cleanup MapCleanupType) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
@@ -995,6 +993,8 @@ func (m *Manager) StopReaders(cleanup MapCleanupType) error {
 
 // stopReaders - Thread unsafe version of Stop. If the lock is not held, it will panic
 func (m *Manager) stopReaders(cleanup MapCleanupType) error {
+	// Signal to other goroutines that something is being stopped
+	m.state = stopping
 	var errs []error
 
 	// Stop perf ring readers
@@ -1061,11 +1061,6 @@ func (m *Manager) stopProbes() error {
 
 // stop - Thread unsafe version of Stop. Requires the manager lock to not panic
 func (m *Manager) stop(cleanup MapCleanupType) error {
-	// Set state to reset early, to prevent concurrent operations (like
-	// NewPerfRing, NewRingBuffer) from adding new readers during the
-	// unlock window.
-	m.state = reset
-
 	var errs []error
 	errs = append(errs, m.stopReaders(cleanup))
 
@@ -1087,7 +1082,7 @@ func (m *Manager) stop(cleanup MapCleanupType) error {
 	// situations. We can't rely only on the collection to close all maps and programs because some pinned objects were
 	// removed from the collection.
 	m.collection.Close()
-
+	m.state = reset
 	return errors.Join(errs...)
 }
 

--- a/manager.go
+++ b/manager.go
@@ -926,7 +926,7 @@ func (m *Manager) Stop(cleanup MapCleanupType) error {
 	return m.stop(cleanup)
 }
 
-// StopReaders stop the kernel events readers Perf or Ring buffer.
+// StopReaders - Stop the kernel events readers Perf or Ring buffer.
 // It is not safe to call NewPerfRing or NewRingBuffer concurrently
 // with StopReaders since we cannot put state to reset here.
 func (m *Manager) StopReaders(cleanup MapCleanupType) error {
@@ -935,6 +935,7 @@ func (m *Manager) StopReaders(cleanup MapCleanupType) error {
 	return m.stopReaders(cleanup)
 }
 
+// stopReaders - Thread unsafe version of Stop. If the lock is not held, it will panic
 func (m *Manager) stopReaders(cleanup MapCleanupType) error {
 	var errs []error
 
@@ -1000,6 +1001,7 @@ func (m *Manager) stopProbes() error {
 	return eg.Wait()
 }
 
+// stop - Thread unsafe version of Stop. Requires the manager lock to not panic
 func (m *Manager) stop(cleanup MapCleanupType) error {
 	// Set state to reset early, to prevent concurrent operations (like
 	// NewPerfRing, NewRingBuffer) from adding new readers during the
@@ -1537,7 +1539,7 @@ func (m *Manager) UpdateActivatedProbes(selectors []ProbesSelector) error {
 
 	if validationErrs != nil {
 		// Clean up
-		_ = m.stop(CleanInternal)
+		_ = m.Stop(CleanInternal)
 		return fmt.Errorf("probes activation validation failed: %w", validationErrs)
 	}
 

--- a/manager_perfmap.go
+++ b/manager_perfmap.go
@@ -11,8 +11,10 @@ import (
 func (m *Manager) NewPerfRing(spec *ebpf.MapSpec, options MapOptions, perfMapOptions PerfMapOptions) (*ebpf.Map, error) {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
 		return nil, ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
 	}
 
 	// check if the name of the new map is available

--- a/manager_perfmap.go
+++ b/manager_perfmap.go
@@ -12,9 +12,9 @@ func (m *Manager) NewPerfRing(spec *ebpf.MapSpec, options MapOptions, perfMapOpt
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
 	switch m.state {
-	case reset, elfLoaded:
+	case reset, elfLoaded, stopping:
 		return nil, ErrManagerNotInitialized
-	case initialized, stopping, paused, running:
+	case initialized, paused, running:
 	}
 
 	// check if the name of the new map is available

--- a/manager_ringbuffer.go
+++ b/manager_ringbuffer.go
@@ -7,8 +7,10 @@ import "github.com/cilium/ebpf"
 func (m *Manager) NewRingBuffer(spec *ebpf.MapSpec, options MapOptions, ringBufferOptions RingBufferOptions) (*ebpf.Map, error) {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
 		return nil, ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
 	}
 
 	// check if the name of the new map is available

--- a/manager_ringbuffer.go
+++ b/manager_ringbuffer.go
@@ -8,9 +8,9 @@ func (m *Manager) NewRingBuffer(spec *ebpf.MapSpec, options MapOptions, ringBuff
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
 	switch m.state {
-	case reset, elfLoaded:
+	case reset, elfLoaded, stopping:
 		return nil, ErrManagerNotInitialized
-	case initialized, stopping, paused, running:
+	case initialized, paused, running:
 	}
 
 	// check if the name of the new map is available

--- a/map_route.go
+++ b/map_route.go
@@ -29,7 +29,12 @@ type MapRoute struct {
 func (m *Manager) UpdateMapRoutes(router ...MapRoute) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.collection == nil || m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
+		return ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+	}
+	if m.collection == nil {
 		return ErrManagerNotInitialized
 	}
 

--- a/netlink.go
+++ b/netlink.go
@@ -137,8 +137,10 @@ func (m *Manager) GetNetlinkSocket(nsHandle uint64, nsID uint32) (*NetlinkSocket
 func (m *Manager) CleanupNetworkNamespace(nsID uint32) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
 		return ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
 	}
 
 	var errs []error

--- a/perfmap.go
+++ b/perfmap.go
@@ -215,10 +215,10 @@ func (m *PerfMap) Flush() {
 func (m *PerfMap) Stop(cleanup MapCleanupType) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.state <= stopped {
+	if m.state <= stopping {
 		return nil
 	}
-	m.state = stopped
+	m.state = stopping
 
 	// close perf reader
 	err := m.perfReader.Close()
@@ -241,10 +241,10 @@ func (m *PerfMap) Stop(cleanup MapCleanupType) error {
 func (m *PerfMap) closeReader() error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.state <= stopped {
+	if m.state <= stopping {
 		return nil
 	}
-	m.state = stopped
+	m.state = stopping
 	return m.perfReader.Close()
 }
 

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -164,10 +164,10 @@ func (rb *RingBuffer) Flush() {
 func (rb *RingBuffer) Stop(cleanup MapCleanupType) error {
 	rb.stateLock.Lock()
 	defer rb.stateLock.Unlock()
-	if rb.state <= stopped {
+	if rb.state <= stopping {
 		return nil
 	}
-	rb.state = stopped
+	rb.state = stopping
 
 	// close ring reader
 	err := rb.ringReader.Close()
@@ -190,10 +190,10 @@ func (rb *RingBuffer) Stop(cleanup MapCleanupType) error {
 func (rb *RingBuffer) closeReader() error {
 	rb.stateLock.Lock()
 	defer rb.stateLock.Unlock()
-	if rb.state <= stopped {
+	if rb.state <= stopping {
 		return nil
 	}
-	rb.state = stopped
+	rb.state = stopping
 	return rb.ringReader.Close()
 }
 

--- a/state.go
+++ b/state.go
@@ -6,7 +6,7 @@ const (
 	reset state = iota
 	elfLoaded
 	initialized
-	stopped
+	stopping
 	paused
 	running
 )

--- a/tailcall_route.go
+++ b/tailcall_route.go
@@ -28,7 +28,12 @@ type TailCallRoute struct {
 func (m *Manager) UpdateTailCallRoutes(router ...TailCallRoute) error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
-	if m.collection == nil || m.state < initialized {
+	switch m.state {
+	case reset, elfLoaded:
+		return ErrManagerNotInitialized
+	case initialized, stopping, paused, running:
+	}
+	if m.collection == nil {
 		return ErrManagerNotInitialized
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `UpdateActivatedProbes` panic and hardens manager state handling during reader shutdown.

**1. Fix panic in `UpdateActivatedProbes`**

`UpdateActivatedProbes` called `m.stop()` (private, no lock) on validation failure instead of `m.Stop()` (public, acquires the lock). Since `UpdateActivatedProbes` releases `stateLock` before the end of the function, it could call `stop` without holding the lock, which is not expected. This is fixed by calling `m.Stop()`, which properly acquires its own lock after `UpdateActivatedProbes` releases it.

**2. Refactor state checks from `if` to `switch/case`**

Replace all inequality-based state checks (`if m.state < initialized`) with explicit `switch/case` statements. This makes the set of accepted states visible at each call site and eliminates reliance on the numeric ordering of the `state` enum.

Also rename the `stopped` constant to `stopping` to reflect its actual semantics: a transition state, not a terminal state.

**3. Use the transient `stopping` state during reader shutdown**

- `stopReaders()` sets `m.state = stopping` before closing readers, then restores the previous state when it finishes (unless a concurrent `Stop()` has already moved the manager to `reset`).
- `stop()` sets `m.state = reset` only after all resources have been released and rechecks the state after `stopReaders()` because that function temporarily releases the lock.
- During `stopping`, only operations that touch PerfMap/RingBuffer readers are blocked:
  - **Blocked**: `Start`, `Pause`, `Resume`, `NewPerfRing`, `NewRingBuffer` — these interact with readers that are dead or shutting down.
  - **Allowed**: all getters (`GetMap`, `GetProbe`, `GetProgram`, etc.), probe operations (`AddHook`, `DetachHook`, `CloneProgram`, `UpdateActivatedProbes`), map/route operations (`NewMap`, `UpdateMapRoutes`, `UpdateTailCallRoutes`), `CleanupNetworkNamespace`, and `Stop` — these resources are not affected by `stopReaders`.

This prevents races where `NewPerfRing`/`NewRingBuffer` could create new readers during the `stopReaders` unlock window, while preserving the manager's state after a standalone `StopReaders()` call and still allowing probe and map operations during graceful shutdown.

**4. Retract affected releases**

Retract `v0.8.5` and `v0.8.6` in `go.mod` because these versions can panic.

### Motivation

Follow-up to #288 and #289. The deadlock fix in #288 introduced an unlock window in `stopReaders` where `m.state` was set to `reset` too early, which broke concurrent accessors. The transient `stopping` state communicates that readers are shutting down while the other resources are still alive.
